### PR TITLE
Remove simple volume. Match ccs script naming.

### DIFF
--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -60,9 +60,6 @@ class CO2Leakage(WebvizPluginABC):
     * **`co2_containment_volume_actual_relpath`:** Path to a table of co2 containment data (amount
         of CO2 outside/inside a boundary), for co2 volume of type "actual". Relative to each
         realization.
-    * **`co2_containment_volume_actual_simple_relpath`:** Path to a table of co2 containment data
-        (amount of CO2 outside/inside a boundary), for co2 volume of type "actual_simple".
-        Relative to each realization.
     * **`unsmry_relpath`:** Relative path to a csv version of a unified summary file
     * **`fault_polygon_attribute`:** Polygons with this attribute are used as fault
         polygons
@@ -94,8 +91,6 @@ class CO2Leakage(WebvizPluginABC):
         co2_containment_relpath: str = TILE_PATH + "/co2_volumes.csv",
         co2_containment_volume_actual_relpath: str = TILE_PATH
         + "/plume_volume_actual.csv",
-        co2_containment_volume_actual_simple_relpath: str = TILE_PATH
-        + "/plume_volume_actual_simple.csv",
         unsmry_relpath: str = TILE_PATH + "/unsmry--raw.csv",
         fault_polygon_attribute: str = "dl_extracted_faultlines",
         initial_surface: Optional[str] = None,
@@ -141,10 +136,6 @@ class CO2Leakage(WebvizPluginABC):
             self._co2_volume_actual_table_providers = init_table_provider(
                 self._ensemble_paths,
                 co2_containment_volume_actual_relpath,
-            )
-            self._co2_volume_actual_simple_table_providers = init_table_provider(
-                self._ensemble_paths,
-                co2_containment_volume_actual_simple_relpath,
             )
             self._unsmry_providers = init_table_provider(
                 self._ensemble_paths,
@@ -239,7 +230,6 @@ class CO2Leakage(WebvizPluginABC):
             if source in [
                 GraphSource.CONTAINMENT_MASS,
                 GraphSource.CONTAINMENT_VOLUME_ACTUAL,
-                GraphSource.CONTAINMENT_VOLUME_ACTUAL_SIMPLE,
             ]:
                 y_limits = []
                 if len(y_min_auto) == 0:
@@ -268,16 +258,6 @@ class CO2Leakage(WebvizPluginABC):
                 ):
                     figs[: len(figs)] = generate_containment_figures(
                         self._co2_volume_actual_table_providers[ensemble],
-                        co2_scale,
-                        realizations[0],
-                        y_limits,
-                    )
-                elif (
-                    source == GraphSource.CONTAINMENT_VOLUME_ACTUAL_SIMPLE
-                    and ensemble in self._co2_volume_actual_simple_table_providers
-                ):
-                    figs[: len(figs)] = generate_containment_figures(
-                        self._co2_volume_actual_simple_table_providers[ensemble],
                         co2_scale,
                         realizations[0],
                         y_limits,
@@ -333,10 +313,7 @@ class CO2Leakage(WebvizPluginABC):
             Tuple[List[Co2MassScale], Co2MassScale],
             Tuple[List[Co2VolumeScale], Co2VolumeScale],
         ]:
-            if attribute in [
-                GraphSource.CONTAINMENT_VOLUME_ACTUAL,
-                GraphSource.CONTAINMENT_VOLUME_ACTUAL_SIMPLE,
-            ]:
+            if attribute == GraphSource.CONTAINMENT_VOLUME_ACTUAL:
                 return list(Co2VolumeScale), Co2VolumeScale.BILLION_CUBIC_METERS
 
             return list(Co2MassScale), Co2MassScale.MTONS

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -55,9 +55,9 @@ class CO2Leakage(WebvizPluginABC):
     * **`file_containment_boundary`:** Path to a polygon representing the containment area
     * **`file_hazardous_boundary`:** Path to a polygon representing the hazardous area
     * **`well_pick_file`:** Path to a file containing well picks
-    * **`co2_containment_relpath`:** Path to a table of co2 containment data (amount of
+    * **`plume_mass_relpath`:** Path to a table of co2 containment data (amount of
         CO2 outside/inside a boundary), for co2 mass. Relative to each realization.
-    * **`co2_containment_actual_volume_relpath`:** Path to a table of co2 containment data (amount
+    * **`plume_actual_volume_relpath`:** Path to a table of co2 containment data (amount
         of CO2 outside/inside a boundary), for co2 volume of type "actual". Relative to each
         realization.
     * **`unsmry_relpath`:** Relative path to a csv version of a unified summary file
@@ -88,9 +88,9 @@ class CO2Leakage(WebvizPluginABC):
         file_containment_boundary: Optional[str] = None,
         file_hazardous_boundary: Optional[str] = None,
         well_pick_file: Optional[str] = None,
-        co2_containment_relpath: str = TILE_PATH + "/co2_containment_mass.csv",
-        co2_containment_actual_volume_relpath: str = TILE_PATH
-        + "/co2_containment_actual_volume.csv",
+        plume_mass_relpath: str = TILE_PATH + "/plume_mass.csv",
+        plume_actual_volume_relpath: str = TILE_PATH
+        + "/plume_actual_volume.csv",
         unsmry_relpath: str = TILE_PATH + "/unsmry--raw.csv",
         fault_polygon_attribute: str = "dl_extracted_faultlines",
         initial_surface: Optional[str] = None,
@@ -131,11 +131,11 @@ class CO2Leakage(WebvizPluginABC):
             # CO2 containment
             self._co2_table_providers = init_table_provider(
                 self._ensemble_paths,
-                co2_containment_relpath,
+                plume_mass_relpath,
             )
             self._co2_actual_volume_table_providers = init_table_provider(
                 self._ensemble_paths,
-                co2_containment_actual_volume_relpath,
+                plume_actual_volume_relpath,
             )
             self._unsmry_providers = init_table_provider(
                 self._ensemble_paths,

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -57,7 +57,7 @@ class CO2Leakage(WebvizPluginABC):
     * **`well_pick_file`:** Path to a file containing well picks
     * **`co2_containment_relpath`:** Path to a table of co2 containment data (amount of
         CO2 outside/inside a boundary), for co2 mass. Relative to each realization.
-    * **`co2_containment_volume_actual_relpath`:** Path to a table of co2 containment data (amount
+    * **`co2_containment_actual_volume_relpath`:** Path to a table of co2 containment data (amount
         of CO2 outside/inside a boundary), for co2 volume of type "actual". Relative to each
         realization.
     * **`unsmry_relpath`:** Relative path to a csv version of a unified summary file
@@ -88,9 +88,9 @@ class CO2Leakage(WebvizPluginABC):
         file_containment_boundary: Optional[str] = None,
         file_hazardous_boundary: Optional[str] = None,
         well_pick_file: Optional[str] = None,
-        co2_containment_relpath: str = TILE_PATH + "/co2_volumes.csv",
-        co2_containment_volume_actual_relpath: str = TILE_PATH
-        + "/plume_volume_actual.csv",
+        co2_containment_relpath: str = TILE_PATH + "/co2_containment_mass.csv",
+        co2_containment_actual_volume_relpath: str = TILE_PATH
+        + "/co2_containment_actual_volume.csv",
         unsmry_relpath: str = TILE_PATH + "/unsmry--raw.csv",
         fault_polygon_attribute: str = "dl_extracted_faultlines",
         initial_surface: Optional[str] = None,
@@ -133,9 +133,9 @@ class CO2Leakage(WebvizPluginABC):
                 self._ensemble_paths,
                 co2_containment_relpath,
             )
-            self._co2_volume_actual_table_providers = init_table_provider(
+            self._co2_actual_volume_table_providers = init_table_provider(
                 self._ensemble_paths,
-                co2_containment_volume_actual_relpath,
+                co2_containment_actual_volume_relpath,
             )
             self._unsmry_providers = init_table_provider(
                 self._ensemble_paths,
@@ -229,7 +229,7 @@ class CO2Leakage(WebvizPluginABC):
             figs = [no_update] * 3
             if source in [
                 GraphSource.CONTAINMENT_MASS,
-                GraphSource.CONTAINMENT_VOLUME_ACTUAL,
+                GraphSource.CONTAINMENT_ACTUAL_VOLUME,
             ]:
                 y_limits = []
                 if len(y_min_auto) == 0:
@@ -253,11 +253,11 @@ class CO2Leakage(WebvizPluginABC):
                         y_limits,
                     )
                 elif (
-                    source == GraphSource.CONTAINMENT_VOLUME_ACTUAL
-                    and ensemble in self._co2_volume_actual_table_providers
+                    source == GraphSource.CONTAINMENT_ACTUAL_VOLUME
+                    and ensemble in self._co2_actual_volume_table_providers
                 ):
                     figs[: len(figs)] = generate_containment_figures(
-                        self._co2_volume_actual_table_providers[ensemble],
+                        self._co2_actual_volume_table_providers[ensemble],
                         co2_scale,
                         realizations[0],
                         y_limits,
@@ -313,7 +313,7 @@ class CO2Leakage(WebvizPluginABC):
             Tuple[List[Co2MassScale], Co2MassScale],
             Tuple[List[Co2VolumeScale], Co2VolumeScale],
         ]:
-            if attribute == GraphSource.CONTAINMENT_VOLUME_ACTUAL:
+            if attribute == GraphSource.CONTAINMENT_ACTUAL_VOLUME:
                 return list(Co2VolumeScale), Co2VolumeScale.BILLION_CUBIC_METERS
 
             return list(Co2MassScale), Co2MassScale.MTONS

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -310,6 +310,10 @@ def create_map_layers(
         well_data = dict(well_pick_provider.get_geojson(selected_wells, formation))
         if "features" in well_data and len(well_data["features"]) == 0:
             warnings.warn(f'Formation name "{formation}" not found in well picks file.')
+        else:
+            for i in range(len(well_data["features"])):
+                current_attribute = well_data["features"][i]["properties"]["attribute"]
+                well_data["features"][i]["properties"]["attribute"] = " " + current_attribute
         layers.append(
             {
                 "@@type": "GeoJsonLayer",

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -308,9 +308,9 @@ def create_map_layers(
         and LayoutLabels.SHOW_WELLS in options_dialog_options
     ):
         well_data = dict(well_pick_provider.get_geojson(selected_wells, formation))
-        if "features" in well_data and len(well_data["features"]) == 0:
-            warnings.warn(f'Formation name "{formation}" not found in well picks file.')
-        else:
+        if "features" in well_data:
+            if len(well_data["features"]) == 0:
+                warnings.warn(f'Formation name "{formation}" not found in well picks file.')
             for i in range(len(well_data["features"])):
                 current_attribute = well_data["features"][i]["properties"]["attribute"]
                 well_data["features"][i]["properties"]["attribute"] = " " + current_attribute

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -27,7 +27,6 @@ class GraphSource(StrEnum):
     UNSMRY = "UNSMRY"
     CONTAINMENT_MASS = "Containment Data (mass)"
     CONTAINMENT_VOLUME_ACTUAL = "Containment Data (volume, actual)"
-    CONTAINMENT_VOLUME_ACTUAL_SIMPLE = "Containment Data (volume, actual_simple)"
 
 
 class LayoutLabels(str, Enum):

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -26,7 +26,7 @@ class Co2VolumeScale(StrEnum):
 class GraphSource(StrEnum):
     UNSMRY = "UNSMRY"
     CONTAINMENT_MASS = "Containment Data (mass)"
-    CONTAINMENT_VOLUME_ACTUAL = "Containment Data (volume, actual)"
+    CONTAINMENT_ACTUAL_VOLUME = "Containment Data (volume, actual)"
 
 
 class LayoutLabels(str, Enum):


### PR DESCRIPTION
Solves issues:
- https://github.com/equinor/ccs-scripts/issues/17
- https://github.com/equinor/ccs-scripts/issues/25

Also adds a space before well names so that the w is not eaten by the dot indicating the location of the well.