### PR TITLE
Fix zoom reset and minor formatting in containment plots

### DIFF
--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -270,7 +270,10 @@ class CO2Leakage(WebvizPluginABC):
                 )
                 figs[: len(u_figs)] = u_figs
                 styles[: len(u_figs)] = [{}] * len(u_figs)
-
+            for i in range(len(figs)):
+                figs[i]["layout"]["uirevision"] = f"{source}-{co2_scale}"
+                if i == len(figs) - 1:
+                    figs[i]["layout"]["uirevision"] += f"-{realizations}"
             return *figs, *styles  # type: ignore
 
         @callback(
@@ -340,6 +343,7 @@ class CO2Leakage(WebvizPluginABC):
             Input(ViewSettings.Ids.OPTIONS_DIALOG_OPTIONS, "value"),
             Input(ViewSettings.Ids.OPTIONS_DIALOG_WELL_FILTER, "value"),
             State(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
+            State(self._view_component(MapViewElement.Ids.DECKGL_MAP), "views"),
         )
         def update_map_attribute(
             attribute: MapAttribute,
@@ -357,6 +361,7 @@ class CO2Leakage(WebvizPluginABC):
             options_dialog_options: List[int],
             selected_wells: List[str],
             ensemble: str,
+            current_views: List[Any],
         ) -> Tuple[List[Dict[Any, Any]], List[Any], Dict[Any, Any]]:
             attribute = MapAttribute(attribute)
             if len(realization) == 0:
@@ -426,7 +431,7 @@ class CO2Leakage(WebvizPluginABC):
                 surface_data=surf_data,
                 colortables=self._color_tables,
             )
-            viewports = create_map_viewports()
+            viewports = no_update if current_views else create_map_viewports()
             return (layers, annotations, viewports)
 
         @callback(

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
@@ -240,6 +240,7 @@ def generate_co2_time_containment_one_realization_figure(
     )
     fig.layout.xaxis.title = "Time"
     fig.layout.yaxis.title = scale.value
+    fig.layout.yaxis.exponentformat = "power"
     _adjust_figure(fig)
     return fig
 
@@ -268,7 +269,7 @@ def generate_co2_time_containment_figure(
     }
     active_cols_at_startup = ["Total", "Outside", "Hazardous"]
     # Generate dummy scatters for legend entries
-    dummy_args = {"mode": "lines", "hoverinfo": "none"}
+    dummy_args = {"x": df["date"], "mode": "lines", "hoverinfo": "none"}
     for col, value in cols_to_plot.items():
         args = {
             "line_dash": value[1],
@@ -305,8 +306,8 @@ def generate_co2_time_containment_figure(
     fig.layout.title = "CO<sub>2</sub> containment (all realizations)"
     fig.layout.xaxis.title = "Time"
     fig.layout.yaxis.title = scale.value
-    fig.layout.yaxis.exponentformat = "none"
-    fig.layout.yaxis.range = (0, 1.05 * df["total"].max())
+    fig.layout.yaxis.exponentformat = "power"
+    fig.layout.yaxis.range = (-0.1 * df["total"].max(), 1.1 * df["total"].max())
     _adjust_figure(fig)
     # fig.update_layout(legend=dict(font=dict(size=8)), legend_tracegroupgap=0)
     return fig


### PR DESCRIPTION
Resolves https://github.com/equinor/ccs-scripts/issues/34

Also makes the formatting of a billion consistent across the containment plots, and fixes the xrange of the middle one.
