### PR TITLE
Edit standard surface filenames and fix settings buttons

### DIFF
--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -443,6 +443,7 @@ class CO2Leakage(WebvizPluginABC):
                     color_map_name=color_map_name,
                     readable_name_=readable_name(attribute),
                     visualization_threshold=self._visualization_threshold,
+                    map_attribute_names=self._map_attribute_names,
                 )
             surf_data, self._summed_co2 = process_summed_mass(
                 formation,

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -357,6 +357,9 @@ class CO2Leakage(WebvizPluginABC):
             Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "layers"),
             Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "children"),
             Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "views"),
+            Output(
+                self._settings_component(ViewSettings.Ids.VISUALIZATION_UPDATE), "n_clicks"
+            ),
             Input(self._settings_component(ViewSettings.Ids.PROPERTY), "value"),
             Input(self._view_component(MapViewElement.Ids.DATE_SLIDER), "value"),
             Input(self._settings_component(ViewSettings.Ids.FORMATION), "value"),
@@ -369,12 +372,12 @@ class CO2Leakage(WebvizPluginABC):
             Input(self._settings_component(ViewSettings.Ids.CM_MAX), "value"),
             Input(self._settings_component(ViewSettings.Ids.PLUME_THRESHOLD), "value"),
             Input(self._settings_component(ViewSettings.Ids.PLUME_SMOOTHING), "value"),
-            Input(
+            State(
                 self._settings_component(ViewSettings.Ids.VISUALIZATION_THRESHOLD),
                 "value",
             ),
             Input(
-                self._settings_component(ViewSettings.Ids.VISUALIZATION_SHOW_0), "value"
+                self._settings_component(ViewSettings.Ids.VISUALIZATION_UPDATE), "n_clicks"
             ),
             Input(ViewSettings.Ids.OPTIONS_DIALOG_OPTIONS, "value"),
             Input(ViewSettings.Ids.OPTIONS_DIALOG_WELL_FILTER, "value"),
@@ -395,7 +398,7 @@ class CO2Leakage(WebvizPluginABC):
             plume_threshold: Optional[float],
             plume_smoothing: Optional[float],
             visualization_threshold: Optional[float],
-            visualize_0: List[str],
+            visualization_update: int,
             options_dialog_options: List[int],
             selected_wells: List[str],
             ensemble: str,
@@ -416,7 +419,7 @@ class CO2Leakage(WebvizPluginABC):
             # Unable to clear cache (when needed) without the protected member
             # pylint: disable=protected-access
             self._visualization_threshold = process_visualization_info(
-                visualize_0,
+                visualization_update,
                 visualization_threshold,
                 self._visualization_threshold,
                 self._surface_server._image_cache,
@@ -488,7 +491,7 @@ class CO2Leakage(WebvizPluginABC):
                 attribute=attribute,
             )
             viewports = no_update if current_views else create_map_viewports()
-            return layers, annotations, viewports
+            return layers, annotations, viewports, 0
 
         @callback(
             Output(ViewSettings.Ids.OPTIONS_DIALOG, "open"),

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -358,7 +358,8 @@ class CO2Leakage(WebvizPluginABC):
             Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "children"),
             Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "views"),
             Output(
-                self._settings_component(ViewSettings.Ids.VISUALIZATION_UPDATE), "n_clicks"
+                self._settings_component(ViewSettings.Ids.VISUALIZATION_UPDATE),
+                "n_clicks",
             ),
             Input(self._settings_component(ViewSettings.Ids.PROPERTY), "value"),
             Input(self._view_component(MapViewElement.Ids.DATE_SLIDER), "value"),
@@ -377,7 +378,8 @@ class CO2Leakage(WebvizPluginABC):
                 "value",
             ),
             Input(
-                self._settings_component(ViewSettings.Ids.VISUALIZATION_UPDATE), "n_clicks"
+                self._settings_component(ViewSettings.Ids.VISUALIZATION_UPDATE),
+                "n_clicks",
             ),
             Input(ViewSettings.Ids.OPTIONS_DIALOG_OPTIONS, "value"),
             Input(ViewSettings.Ids.OPTIONS_DIALOG_WELL_FILTER, "value"),
@@ -403,7 +405,7 @@ class CO2Leakage(WebvizPluginABC):
             selected_wells: List[str],
             ensemble: str,
             current_views: List[Any],
-        ) -> Tuple[List[Dict[Any, Any]], List[Any], Dict[Any, Any]]:
+        ) -> Tuple[List[Dict[Any, Any]], List[Any], Dict[Any, Any], int]:
             attribute = MapAttribute(attribute)
             if len(realization) == 0 or ensemble is None:
                 raise PreventUpdate

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -77,12 +77,14 @@ class SurfaceData:
         color_map_name: str,
         readable_name_: str,
         visualization_threshold: float,
+        map_attribute_names: Dict[MapAttribute, str],
     ) -> Tuple[Any, Optional[Any]]:
         surf_meta, img_url, summed_mass = publish_and_get_surface_metadata(
             server,
             provider,
             address,
             visualization_threshold,
+            map_attribute_names,
         )
         assert surf_meta is not None  # Should not occur
         value_range = (
@@ -327,6 +329,7 @@ def create_map_layers(
         )
     if (
         well_pick_provider is not None
+        and formation is not None
         and LayoutLabels.SHOW_WELLS in options_dialog_options
     ):
         well_data = dict(well_pick_provider.get_geojson(selected_wells, formation))

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -454,23 +454,23 @@ def _parse_polygon_file(filename: str) -> Dict[str, Any]:
 
 
 def process_visualization_info(
-    visualize_0: List[str],
-    visualization_threshold: Optional[float],
+    n_clicks: int,
+    threshold: Optional[float],
     stored_threshold: float,
     cache: Cache,
 ) -> float:
-    if len(visualize_0) != 0:
-        visualization_threshold = -1.0
-    elif visualization_threshold is None:
-        visualization_threshold = 1e-10
-    # Clear surface cache if the threshold for visualization is changed
-    if stored_threshold != visualization_threshold:
+    if threshold is None:
+        print("Visualization threshold must be a number.")
+        return stored_threshold
+    if n_clicks > 0 and threshold != stored_threshold:
+        # Clear surface cache if the threshold for visualization is changed
         print(
             "Clearing cache because the visualization threshold was changed\n"
             "Re-select realization(s) to update the current map"
         )
         cache.clear()
-    return visualization_threshold
+        return threshold
+    return stored_threshold
 
 
 def process_zone_info(

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -56,6 +56,14 @@ class LayoutStyle:
         "background-color": "lightgrey",
     }
 
+    FEEDBACK_BUTTON = {
+        "marginBottom": "10px",
+        "width": "100%",
+        "height": "30px",
+        "line-height": "30px",
+        "background-color": "lightgrey",
+    }
+
 
 class ZoneViews(StrEnum):
     CONTAINMENTSPLIT = "Split into containment polygons"

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -42,6 +42,7 @@ class LayoutLabels(str, Enum):
     WELL_FILTER = "Well filter"
     COMMON_SELECTIONS = "Options and global filters"
     FEEDBACK = "User feedback"
+    VISUALIZATION_UPDATE = "Update threshold"
 
 
 # pylint: disable=too-few-public-methods
@@ -59,6 +60,13 @@ class LayoutStyle:
     FEEDBACK_BUTTON = {
         "marginBottom": "10px",
         "width": "100%",
+        "height": "30px",
+        "line-height": "30px",
+        "background-color": "lightgrey",
+    }
+
+    VISUALIZATION_BUTTON = {
+        "marginLeft": "10px",
         "height": "30px",
         "line-height": "30px",
         "background-color": "lightgrey",

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
@@ -36,10 +36,9 @@ def init_map_attribute_names(
             MapAttribute.MIGRATION_TIME: "migrationtime",
             MapAttribute.MAX_SGAS: "max_sgas",
             MapAttribute.MAX_AMFG: "max_amfg",
-            # MapAttribute.MASS: "mass_total",  # NBNB-AS: Or sum_mass_total
-            MapAttribute.MASS: "mass",
-            MapAttribute.DISSOLVED: "dissolved_mass",
-            MapAttribute.FREE: "free_mass",
+            MapAttribute.MASS: "co2-mass-total",
+            MapAttribute.DISSOLVED: "co2-mass-aqu-phase",
+            MapAttribute.FREE: "co2-mass-gas-phase",
         }
     return {MapAttribute[key]: value for key, value in mapping.items()}
 

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import xtgeo
@@ -16,6 +16,7 @@ from webviz_subsurface._providers import (
 from webviz_subsurface._providers.ensemble_surface_provider.ensemble_surface_provider import (
     SurfaceStatistic,
 )
+from webviz_subsurface.plugins._co2_leakage._utilities.generic import MapAttribute
 from webviz_subsurface.plugins._co2_leakage._utilities.plume_extent import (
     truncate_surfaces,
 )
@@ -40,6 +41,7 @@ def publish_and_get_surface_metadata(
     provider: EnsembleSurfaceProvider,
     address: Union[SurfaceAddress, TruncatedSurfaceAddress],
     visualization_threshold: float,
+    map_attribute_names: Dict[MapAttribute, str],
 ) -> Tuple[Optional[SurfaceImageMeta], str, Optional[Any]]:
     if isinstance(address, TruncatedSurfaceAddress):
         return _publish_and_get_truncated_surface_metadata(server, provider, address)
@@ -53,7 +55,10 @@ def publish_and_get_surface_metadata(
         if not surface:
             raise ValueError(f"Could not get surface for address: {address}")
         summed_mass = np.ma.sum(surface.values)
-        if address.attribute != "MigrationTime" and visualization_threshold >= 0:
+        if (
+            address.attribute != map_attribute_names[MapAttribute.MIGRATION_TIME]
+            and visualization_threshold >= 0
+        ):
             surface.operation("elile", visualization_threshold)
         server.publish_surface(qualified_address, surface)
         surf_meta = server.get_surface_metadata(qualified_address)

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -443,16 +443,15 @@ class MapSelectorLayout(wcc.Selectors):
                                     id=visualization_threshold_id,
                                     type="number",
                                     value=-1,
-                                    style={"width": "70%"}
+                                    style={"width": "70%"},
                                 ),
-                                html.Div(
-                                    style={"width": "5%"}
-                                ),
+                                html.Div(style={"width": "5%"}),
                                 html.Button(
-                                    'Update',
+                                    "Update",
                                     id=visualization_update_id,
                                     style=LayoutStyle.VISUALIZATION_BUTTON,
-                                    n_clicks=0),
+                                    n_clicks=0,
+                                ),
                             ],
                             style={"display": "flex"},
                         ),

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -55,7 +55,7 @@ class ViewSettings(SettingsGroupABC):
         PLUME_SMOOTHING = "plume-smoothing"
 
         VISUALIZATION_THRESHOLD = "visualization-threshold"
-        VISUALIZATION_SHOW_0 = "visualization-show-0"
+        VISUALIZATION_UPDATE = "visualization-update"
 
         FEEDBACK_BUTTON = "feedback-button"
         FEEDBACK = "feedback"
@@ -106,7 +106,7 @@ class ViewSettings(SettingsGroupABC):
                 self.register_component_unique_id(self.Ids.CM_MIN_AUTO),
                 self.register_component_unique_id(self.Ids.CM_MAX_AUTO),
                 self.register_component_unique_id(self.Ids.VISUALIZATION_THRESHOLD),
-                self.register_component_unique_id(self.Ids.VISUALIZATION_SHOW_0),
+                self.register_component_unique_id(self.Ids.VISUALIZATION_UPDATE),
             ),
             GraphSelectorsLayout(
                 self.register_component_unique_id(self.Ids.GRAPH_SOURCE),
@@ -218,17 +218,10 @@ class ViewSettings(SettingsGroupABC):
                 self.component_unique_id(self.Ids.VISUALIZATION_THRESHOLD).to_string(),
                 "disabled",
             ),
-            Input(
-                self.component_unique_id(self.Ids.VISUALIZATION_SHOW_0).to_string(),
-                "value",
-            ),
             Input(self.component_unique_id(self.Ids.PROPERTY).to_string(), "value"),
         )
-        def set_visualization_threshold(show_0: List[str], attribute: str) -> bool:
-            return (
-                len(show_0) == 1
-                or MapAttribute(attribute) == MapAttribute.MIGRATION_TIME
-            )
+        def set_visualization_threshold(attribute: str) -> bool:
+            return MapAttribute(attribute) == MapAttribute.MIGRATION_TIME
 
         @callback(
             Output(
@@ -378,7 +371,7 @@ class MapSelectorLayout(wcc.Selectors):
         cm_min_auto_id: str,
         cm_max_auto_id: str,
         visualization_threshold_id: str,
-        visualization_show_0_id: str,
+        visualization_update_id: str,
     ):
         default_colormap = (
             "turbo (Seq)"
@@ -446,14 +439,22 @@ class MapSelectorLayout(wcc.Selectors):
                         "Visualization threshold",
                         html.Div(
                             [
-                                dcc.Input(id=visualization_threshold_id, type="number"),
-                                dcc.Checklist(
-                                    ["Show 0"],
-                                    ["Show 0"],
-                                    id=visualization_show_0_id,
+                                dcc.Input(
+                                    id=visualization_threshold_id,
+                                    type="number",
+                                    value=-1,
+                                    style={"width": "70%"}
                                 ),
+                                html.Div(
+                                    style={"width": "5%"}
+                                ),
+                                html.Button(
+                                    'Update',
+                                    id=visualization_update_id,
+                                    style=LayoutStyle.VISUALIZATION_BUTTON,
+                                    n_clicks=0),
                             ],
-                            style=self._CM_RANGE,
+                            style={"display": "flex"},
                         ),
                     ],
                 )

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -666,7 +666,7 @@ class FeedbackLayout(wcc.Dialog):
 
 class FeedbackButton(html.Button):
     def __init__(self) -> None:
-        style = LayoutStyle.OPTIONS_BUTTON
+        style = LayoutStyle.FEEDBACK_BUTTON
         style["display"] = "none"
         super().__init__(
             LayoutLabels.FEEDBACK,

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Dict, List, Optional, Tuple
 
 import dash
@@ -163,6 +164,11 @@ class ViewSettings(SettingsGroupABC):
             # Map
             prop_name = property_origin(MapAttribute(prop), self._map_attribute_names)
             surfaces = surface_provider.surface_names_for_attribute(prop_name)
+            if len(surfaces) == 0:
+                warnings.warn(
+                    f"Surface not found for property: {prop}.\n"
+                    f"Expected name: <formation>--{prop_name}--<date>.gri"
+                )
             # Formation names
             formations = [{"label": v.title(), "value": v} for v in surfaces]
             picked_formation = None


### PR DESCRIPTION
Standard names for surface files in accordance with the latest updates to xtgeoapp-grd3dmaps-as.

The options button was made invisible by mistake, reenabled now.

Made some changes to the visualization threshold to make it more intuitive. Now the user writes the desired threshold, then presses the "Update" button to update. Still need to de-select and re-select the current realization to actually update the plot, will look into this in January.