### PR TITLE
Expand containment plot options

### DIFF
--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -258,9 +258,7 @@ class CO2Leakage(WebvizPluginABC):
             Input(self._settings_component(ViewSettings.Ids.REGION), "value"),
             Input(self._settings_component(ViewSettings.Ids.CONTAINMENT_VIEW), "value"),
             Input(self._settings_component(ViewSettings.Ids.PHASE), "value"),
-            Input(
-                self._view_component(MapViewElement.Ids.CONTAINMENT_CHECKBOXES), "value"
-            ),
+            Input(self._settings_component(ViewSettings.Ids.COLOR_OPTIONS), "value"),
         )
         @callback_typecheck
         def update_graphs(
@@ -570,31 +568,6 @@ class CO2Leakage(WebvizPluginABC):
             raise PreventUpdate
 
         @callback(
-            Output(
-                self._view_component(MapViewElement.Ids.CONTAINMENT_CHECKBOXES),
-                "options",
-            ),
-            Output(
-                self._view_component(MapViewElement.Ids.CONTAINMENT_CHECKBOXES), "style"
-            ),
-            Input(self._settings_component(ViewSettings.Ids.CONTAINMENT_VIEW), "value"),
-        )
-        def hide_bar_plot_checkboxes(view: str) -> Tuple[List[Dict], Dict]:
-            if view == ContainmentViews.CONTAINMENTSPLIT:
-                return [], {"display": "none"}
-            style = {
-                "display": "flex",
-                "flexDirection": "row",
-            }
-            split = "zones" if view == ContainmentViews.ZONESPLIT else "regions"
-            options = [
-                {"label": f"Sort by {split}", "value": 0},
-                {"label": "Sort by containment", "value": 1},
-                {"label": "Color by containment", "value": 2},
-            ]
-            return options, style
-
-        @callback(
             Output(self._view_component(MapViewElement.Ids.TOP_ELEMENT), "style"),
             Output(self._view_component(MapViewElement.Ids.BOTTOM_ELEMENT), "style"),
             Output(self._view_component(MapViewElement.Ids.BAR_PLOT), "style"),
@@ -616,9 +589,9 @@ class CO2Leakage(WebvizPluginABC):
             source: GraphSource,
         ):
             bottom_style["height"] = f"{slider_value}vh"
-            top_style["height"] = f"{79 - slider_value}vh"
+            top_style["height"] = f"{80 - slider_value}vh"
 
-            styles = [{"height": f"{slider_value * 0.95 - 6}vh", "width": "90%"}] * 3
+            styles = [{"height": f"{slider_value * 0.9 - 4}vh", "width": "90%"}] * 3
             if (
                 (source == GraphSource.UNSMRY and self._unsmry_providers is None)
                 or (

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -30,7 +30,6 @@ from webviz_subsurface.plugins._co2_leakage._utilities.fault_polygons import (
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     Co2MassScale,
     Co2VolumeScale,
-    ContainmentViews,
     GraphSource,
     MapAttribute,
 )
@@ -275,7 +274,7 @@ class CO2Leakage(WebvizPluginABC):
             containment_view: str,
             phase: str,
             ordering: int,
-        ) -> Tuple[Dict, go.Figure, go.Figure]:
+        ) -> Tuple[Dict, go.Figure, go.Figure, go.Figure]:
             figs = [no_update] * 3
             cont_info = process_containment_info(
                 zone,
@@ -587,22 +586,22 @@ class CO2Leakage(WebvizPluginABC):
             top_style: Dict,
             bottom_style: Dict,
             source: GraphSource,
-        ):
+        ) -> List[Dict]:
             bottom_style["height"] = f"{slider_value}vh"
             top_style["height"] = f"{80 - slider_value}vh"
 
             styles = [{"height": f"{slider_value * 0.9 - 4}vh", "width": "90%"}] * 3
-            if (
-                (source == GraphSource.UNSMRY and self._unsmry_providers is None)
-                or (
-                    source == GraphSource.CONTAINMENT_MASS
-                    and ensemble not in self._co2_table_providers
-                )
-                or (
-                    source == GraphSource.CONTAINMENT_ACTUAL_VOLUME
-                    and ensemble not in self._co2_actual_volume_table_providers
-                )
+            if source == GraphSource.UNSMRY and self._unsmry_providers is None:
+                styles = [{"display": "none"}] * 3
+            elif (
+                source == GraphSource.CONTAINMENT_MASS
+                and ensemble not in self._co2_table_providers
+            ):
+                styles = [{"display": "none"}] * 3
+            elif (
+                source == GraphSource.CONTAINMENT_ACTUAL_VOLUME
+                and ensemble not in self._co2_actual_volume_table_providers
             ):
                 styles = [{"display": "none"}] * 3
 
-            return top_style, bottom_style, *styles
+            return [top_style, bottom_style] + styles

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -30,7 +30,6 @@ from webviz_subsurface.plugins._co2_leakage._utilities.fault_polygons import (
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     Co2MassScale,
     Co2VolumeScale,
-    ContainmentViews,
     GraphSource,
     MapAttribute,
 )
@@ -238,9 +237,6 @@ class CO2Leakage(WebvizPluginABC):
         # to determine what to plot
         # pylint: disable=too-many-arguments
         @callback(
-            Output(
-                self._settings_component(ViewSettings.Ids.CONTAINMENT_VIEW), "value"
-            ),
             Output(self._view_component(MapViewElement.Ids.BAR_PLOT), "figure"),
             Output(self._view_component(MapViewElement.Ids.TIME_PLOT), "figure"),
             Output(
@@ -256,7 +252,6 @@ class CO2Leakage(WebvizPluginABC):
             Input(self._settings_component(ViewSettings.Ids.Y_MAX_GRAPH), "value"),
             Input(self._settings_component(ViewSettings.Ids.ZONE), "value"),
             Input(self._settings_component(ViewSettings.Ids.REGION), "value"),
-            #Input(self._settings_component(ViewSettings.Ids.CONTAINMENT_VIEW), "value"),
             Input(self._settings_component(ViewSettings.Ids.PHASE), "value"),
             Input(self._settings_component(ViewSettings.Ids.CONTAINMENT), "value"),
             Input("color_by", "value"),
@@ -275,59 +270,22 @@ class CO2Leakage(WebvizPluginABC):
             y_max_val: Optional[float],
             zone: Optional[str],
             region: Optional[str],
-            #containment_view: str,
             phase: str,
             containment: str,
-            #ordering: int,
             color_choice: str,
             mark_choice: Optional[str],
             sorting: str,
         ) -> Tuple[Dict, go.Figure, go.Figure, go.Figure]:
-            if mark_choice is None:
-                mark_choice = "phase"
-            if color_choice == "containment":
-                if mark_choice == "zone":
-                    containment_view = ContainmentViews.ZONESPLIT
-                    ordering = 2
-                elif mark_choice == "region":
-                    containment_view = ContainmentViews.REGIONSPLIT
-                    ordering = 2
-                else:
-                    containment_view = ContainmentViews.CONTAINMENTSPLIT
-                    ordering = None
-            elif color_choice == "zone":
-                containment_view = ContainmentViews.ZONESPLIT
-                if mark_choice == "containment":
-                    if sorting == "color":
-                        ordering = 0
-                    else:
-                        ordering = 1
-                else:
-                    ordering = 0
-            else:
-                if color_choice != "region":
-                    print("Hmmm, color by should be Region")
-                containment_view = ContainmentViews.REGIONSPLIT
-                if mark_choice == "containment":
-                    if sorting == "color":
-                        ordering = 0
-                    else:
-                        ordering = 1
-                else:
-                    ordering = 0
-
             figs = [no_update] * 3
             cont_info = process_containment_info(
                 zone,
                 region,
                 phase,
                 containment,
-                ordering,
                 color_choice,
                 mark_choice,
                 sorting,
                 self._zone_and_region_options[ensemble][source],
-                source,
             )
             if source in [
                 GraphSource.CONTAINMENT_MASS,
@@ -374,7 +332,7 @@ class CO2Leakage(WebvizPluginABC):
                         """UNSMRY file has not been specified as input.
                          Please use unsmry_relpath in the configuration."""
                     )
-            return cont_info["containment_view"], *figs  # type: ignore
+            return figs  # type: ignore
 
         @callback(
             Output(self._view_component(MapViewElement.Ids.DATE_SLIDER), "marks"),

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -301,7 +301,7 @@ class CO2Leakage(WebvizPluginABC):
                     y_min_val if len(y_min_auto) == 0 else None,
                     y_max_val if len(y_max_auto) == 0 else None,
                 ]
-                out["styles"] = [{}] * 3
+                out["styles"] = [{"height": "29vh", "width": "90%"}] * 3
                 if (
                     source == GraphSource.CONTAINMENT_MASS
                     and ensemble in self._co2_table_providers

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -254,9 +254,9 @@ class CO2Leakage(WebvizPluginABC):
             Input(self._settings_component(ViewSettings.Ids.REGION), "value"),
             Input(self._settings_component(ViewSettings.Ids.PHASE), "value"),
             Input(self._settings_component(ViewSettings.Ids.CONTAINMENT), "value"),
-            Input("color_by", "value"),
-            Input("mark_by", "value"),
-            Input("sorting", "value"),
+            Input(self._settings_component(ViewSettings.Ids.COLOR_BY), "value"),
+            Input(self._settings_component(ViewSettings.Ids.MARK_BY), "value"),
+            Input(self._settings_component(ViewSettings.Ids.SORT_PLOT), "value"),
         )
         @callback_typecheck
         def update_graphs(
@@ -402,7 +402,7 @@ class CO2Leakage(WebvizPluginABC):
             )
 
         # Cannot avoid many arguments and/or locals since all layers of the DeckGL map
-        # needs to be updated simultaneously
+        # need to be updated simultaneously
         # pylint: disable=too-many-arguments,too-many-locals
         @callback(
             Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "layers"),

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -547,6 +547,7 @@ def set_plot_ids(
                 scale,
                 containment_info["zone"],
                 containment_info["region"],
+                containment_info["containment_view"],
                 str(containment_info["phase"]),
                 str(containment_info["ordering"]),
             )

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -489,9 +489,12 @@ def process_visualization_info(
 def process_containment_info(
     zone: Optional[str],
     region: Optional[str],
-    view: Optional[str],
     phase: str,
+    containment: str,
     ordering: int,
+    color_choice: str,
+    mark_choice: str,
+    sorting: str,
     zone_and_region_options: Dict[str, List[str]],
     source: str,
 ) -> Dict[str, Union[str, None, List[str], int]]:
@@ -501,26 +504,18 @@ def process_containment_info(
         GraphSource.CONTAINMENT_MASS,
         GraphSource.CONTAINMENT_ACTUAL_VOLUME,
     ]:
-        if view == ContainmentViews.CONTAINMENTSPLIT:
-            return {
-                "zone": zone,
-                "region": region,
-                "containment_view": view,
-                "phase": None,
-                "ordering": None,
-            }
-        if view == ContainmentViews.ZONESPLIT and len(zones) > 0:
-            zones = [zone_name for zone_name in zones if zone_name != "all"]
-        elif view == ContainmentViews.REGIONSPLIT and len(regions) > 0:
-            regions = [reg_name for reg_name in regions if reg_name != "all"]
+        if "zone" in [color_choice, mark_choice]:
+            view = ContainmentViews.ZONESPLIT
+        elif "region" in [color_choice, mark_choice]:
+            view = ContainmentViews.REGIONSPLIT
         else:
-            return {
-                "zone": zone,
-                "region": region,
-                "containment_view": ContainmentViews.CONTAINMENTSPLIT,
-                "phase": phase,
-                "ordering": ordering,
-            }
+            view = ContainmentViews.CONTAINMENTSPLIT
+        if len(zones) > 0:
+            zones = [zone_name for zone_name in zones if zone_name != "all"]
+        if len(regions) > 0:
+            regions = [reg_name for reg_name in regions if reg_name != "all"]
+        containments = ["hazardous", "outside", "contained"]
+        phases = ["gas", "aqueous"]
         return {
             "zone": zone,
             "region": region,
@@ -528,7 +523,13 @@ def process_containment_info(
             "zones": zones,
             "regions": regions,
             "phase": phase,
+            "containment": containment,
             "ordering": ordering,
+            "color_choice": color_choice,
+            "mark_choice": mark_choice,
+            "sorting": sorting,
+            "phases": phases,
+            "containments": containments,
         }
     return {"containment_view": ContainmentViews.CONTAINMENTSPLIT}
 

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -31,7 +31,6 @@ from webviz_subsurface.plugins._co2_leakage._utilities.co2volume import (
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     Co2MassScale,
     Co2VolumeScale,
-    ContainmentViews,
     GraphSource,
     LayoutLabels,
     MapAttribute,
@@ -491,47 +490,34 @@ def process_containment_info(
     region: Optional[str],
     phase: str,
     containment: str,
-    ordering: int,
     color_choice: str,
-    mark_choice: str,
+    mark_choice: Optional[str],
     sorting: str,
     zone_and_region_options: Dict[str, List[str]],
-    source: str,
 ) -> Dict[str, Union[str, None, List[str], int]]:
+    if mark_choice is None:
+        mark_choice = "phase"
     zones = zone_and_region_options["zones"]
     regions = zone_and_region_options["regions"]
-    if source in [
-        GraphSource.CONTAINMENT_MASS,
-        GraphSource.CONTAINMENT_ACTUAL_VOLUME,
-    ]:
-        if "zone" in [color_choice, mark_choice]:
-            view = ContainmentViews.ZONESPLIT
-        elif "region" in [color_choice, mark_choice]:
-            view = ContainmentViews.REGIONSPLIT
-        else:
-            view = ContainmentViews.CONTAINMENTSPLIT
-        if len(zones) > 0:
-            zones = [zone_name for zone_name in zones if zone_name != "all"]
-        if len(regions) > 0:
-            regions = [reg_name for reg_name in regions if reg_name != "all"]
-        containments = ["hazardous", "outside", "contained"]
-        phases = ["gas", "aqueous"]
-        return {
-            "zone": zone,
-            "region": region,
-            "containment_view": view,
-            "zones": zones,
-            "regions": regions,
-            "phase": phase,
-            "containment": containment,
-            "ordering": ordering,
-            "color_choice": color_choice,
-            "mark_choice": mark_choice,
-            "sorting": sorting,
-            "phases": phases,
-            "containments": containments,
-        }
-    return {"containment_view": ContainmentViews.CONTAINMENTSPLIT}
+    if len(zones) > 0:
+        zones = [zone_name for zone_name in zones if zone_name != "all"]
+    if len(regions) > 0:
+        regions = [reg_name for reg_name in regions if reg_name != "all"]
+    containments = ["hazardous", "outside", "contained"]
+    phases = ["gas", "aqueous"]
+    return {
+        "zone": zone,
+        "region": region,
+        "zones": zones,
+        "regions": regions,
+        "phase": phase,
+        "containment": containment,
+        "color_choice": color_choice,
+        "mark_choice": mark_choice,
+        "sorting": sorting,
+        "phases": phases,
+        "containments": containments,
+    }
 
 
 def set_plot_ids(
@@ -548,9 +534,10 @@ def set_plot_ids(
                 scale,
                 containment_info["zone"],
                 containment_info["region"],
-                containment_info["containment_view"],
                 str(containment_info["phase"]),
-                str(containment_info["ordering"]),
+                str(containment_info["containment"]),
+                containment_info["color_choice"],
+                containment_info["mark_choice"],
             )
         )
         for fig in figs:

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
@@ -393,10 +393,10 @@ def generate_co2_volume_figure(
     fig.layout.xaxis.title = scale.value
     _adjust_figure(fig)
     fig.update_layout(
-        legend=dict(
-            x=1.05,
-            xanchor="left",
-        )
+        legend={
+            "x": 1.05,
+            "xanchor": "left",
+        }
     )
     return fig
 
@@ -514,10 +514,10 @@ def generate_co2_time_containment_one_realization_figure(
     fig.layout.yaxis.exponentformat = "power"
     _adjust_figure(fig)
     fig.update_layout(
-        legend=dict(
-            x=1.05,
-            xanchor="left",
-        )
+        legend={
+            "x": 1.05,
+            "xanchor": "left",
+        }
     )
     return fig
 
@@ -672,9 +672,9 @@ def generate_co2_time_containment_figure(
     fig.layout.yaxis.autorange = True
     _adjust_figure(fig)
     fig.update_layout(
-        legend=dict(
-            x=1.05,
-            xanchor="left",
-        )
+        legend={
+            "x": 1.05,
+            "xanchor": "left",
+        }
     )
     return fig

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
@@ -318,7 +318,7 @@ def _adjust_figure(fig: go.Figure) -> None:
     fig.layout.title.x = 0.5
     fig.layout.paper_bgcolor = "rgba(0,0,0,0)"
     fig.layout.margin.b = 6
-    fig.layout.margin.t = 40
+    fig.layout.margin.t = 15
     fig.layout.margin.l = 10
     fig.layout.margin.r = 10
 
@@ -372,20 +372,25 @@ def generate_co2_volume_figure(
         color=color,
         pattern_shape=pattern_shape,
         pattern_shape_sequence=pattern,
-        title="End-state CO<sub>2</sub> containment (all realizations)",
         orientation="h",
         category_orders=cat_ord,
         color_discrete_sequence=colors,
         hover_data={"prop": True, "real": False},
     )
     fig.layout.legend.title.text = ""
-    fig.layout.legend.orientation = "h"
-    fig.layout.legend.y = -0.3
+    fig.layout.legend.orientation = "v"
     fig.layout.legend.font = {"size": 8}
+    fig.layout.legend.itemwidth = 40
     fig.layout.yaxis.title = "Realization"
     fig.layout.xaxis.exponentformat = "power"
     fig.layout.xaxis.title = scale.value
     _adjust_figure(fig)
+    fig.update_layout(
+        legend=dict(
+            x=1.05,
+            xanchor="left",
+        )
+    )
     return fig
 
 
@@ -494,17 +499,20 @@ def generate_co2_time_containment_one_realization_figure(
         hover_data=["prop"],
     )
     fig.layout.yaxis.range = y_limits
-    fig.layout.legend.orientation = "h"
+    fig.layout.legend.orientation = "v"
     fig.layout.legend.title.text = ""
-    fig.layout.legend.y = -0.3
     fig.layout.legend.font = {"size": 8}
-    fig.layout.title = "CO<sub>2</sub> containment for realization: " + str(
-        time_series_realization
-    )
+    fig.layout.legend.itemwidth = 40
     fig.layout.xaxis.title = "Time"
     fig.layout.yaxis.title = scale.value
     fig.layout.yaxis.exponentformat = "power"
     _adjust_figure(fig)
+    fig.update_layout(
+        legend=dict(
+            x=1.05,
+            xanchor="left",
+        )
+    )
     return fig
 
 
@@ -648,16 +656,20 @@ def generate_co2_time_containment_figure(
             if col not in active_cols_at_startup:
                 args["visible"] = "legendonly"
             fig.add_scatter(y=sub_df[value[0]], **args, **common_args)
-    fig.layout.legend.orientation = "h"
+    fig.layout.legend.orientation = "v"
     fig.layout.legend.title.text = ""
-    fig.layout.legend.y = -0.3
     fig.layout.legend.font = {"size": 8}
+    fig.layout.legend.itemwidth = 40
     fig.layout.legend.tracegroupgap = 0
-    fig.layout.title = "CO<sub>2</sub> containment (all realizations)"
     fig.layout.xaxis.title = "Time"
     fig.layout.yaxis.title = scale.value
     fig.layout.yaxis.exponentformat = "power"
     fig.layout.yaxis.autorange = True
     _adjust_figure(fig)
-    # fig.update_layout(legend=dict(font=dict(size=8)), legend_tracegroupgap=0)
+    fig.update_layout(
+        legend=dict(
+            x=1.05,
+            xanchor="left",
+        )
+    )
     return fig

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -32,12 +32,6 @@ class GraphSource(StrEnum):
     CONTAINMENT_ACTUAL_VOLUME = "Containment Data (volume, actual)"
 
 
-class PhaseOptions(StrEnum):
-    TOTAL = "Total"
-    AQUEOUS = "Aqueous"
-    GAS = "Gas"
-
-
 class LayoutLabels(str, Enum):
     """Text labels used in layout components"""
 

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -80,6 +80,6 @@ class LayoutStyle:
 
 
 class ContainmentViews(StrEnum):
-    CONTAINMENTSPLIT = "Split into containment polygons"
-    ZONESPLIT = "Split into zones"
-    REGIONSPLIT = "Split into regions"
+    CONTAINMENTSPLIT = "phase"
+    ZONESPLIT = "zone"
+    REGIONSPLIT = "region"

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -71,9 +71,3 @@ class LayoutStyle:
         "line-height": "30px",
         "background-color": "lightgrey",
     }
-
-
-class ContainmentViews(StrEnum):
-    CONTAINMENTSPLIT = "phase"
-    ZONESPLIT = "zone"
-    REGIONSPLIT = "region"

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List
 
 import plotly.graph_objects as go
 import webviz_core_components as wcc
-from dash import dcc, html
+from dash import html
 from dash.development.base_component import Component
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewABC, ViewElementABC
@@ -109,9 +109,9 @@ class MapViewElement(ViewElementABC):
                             value=37,
                             vertical=False,
                             marks={
-                                #1: "Top",
+                                # 1: "Top",
                                 37: "Drag to scale the size of the containment plots",
-                                #79: "Bottom",
+                                # 79: "Bottom",
                             },
                         ),
                     ],
@@ -121,7 +121,6 @@ class MapViewElement(ViewElementABC):
                 ),
             ],
             style={
-                # "flex": 3,
                 "display": "flex",
                 "flexDirection": "column",
                 "height": "90vh",

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
@@ -57,7 +57,7 @@ class MapViewElement(ViewElementABC):
                                 ),
                             ],
                             style={
-                                "padding": "1vh",
+                                "padding": "0.5vh",
                                 "height": "37vh",
                                 "position": "relative",
                             },
@@ -75,16 +75,13 @@ class MapViewElement(ViewElementABC):
                         ),
                     ],
                     style={
-                        "height": "47vh",
+                        "height": "45vh",
                     },
                 ),
                 wcc.Frame(
                     # id=get_uuid(LayoutElements.PLOT_VIEW),
                     style={
-                        "height": "33vh",
-                        "display": "flex",
-                        "flexDirection": "row",
-                        "justifyContent": "space-evenly",
+                        "height": "34vh",
                     },
                     children=_summary_graph_layout(
                         self.register_component_unique_id(self.Ids.BAR_PLOT),
@@ -119,25 +116,52 @@ def _summary_graph_layout(
     time_plot_one_realization_id: str,
 ) -> List:
     return [
-        wcc.Graph(
-            id=bar_plot_id,
-            figure=go.Figure(),
-            config={
-                "displayModeBar": False,
-            },
-        ),
-        wcc.Graph(
-            id=time_plot_id,
-            figure=go.Figure(),
-            config={
-                "displayModeBar": False,
-            },
-        ),
-        wcc.Graph(
-            id=time_plot_one_realization_id,
-            figure=go.Figure(),
-            config={
-                "displayModeBar": False,
-            },
+        wcc.Tabs(
+            id="TAB",
+            value="custom",
+            children=[
+                wcc.Tab(
+                    label="End-state CO2 containment (all realizations)",
+                    children=[
+                        html.Div(
+                            wcc.Graph(
+                                id=bar_plot_id,
+                                figure=go.Figure(),
+                                config={
+                                    "displayModeBar": False,
+                                },
+                            ),
+                        ),
+                    ],
+                ),
+                wcc.Tab(
+                    label="CO2 containment over time (all realizations)",
+                    children=[
+                        html.Div(
+                            wcc.Graph(
+                                id=time_plot_id,
+                                figure=go.Figure(),
+                                config={
+                                    "displayModeBar": False,
+                                },
+                            ),
+                        ),
+                    ],
+                ),
+                wcc.Tab(
+                    label="CO2 containment over time (one realization)",
+                    children=[
+                        html.Div(
+                            wcc.Graph(
+                                id=time_plot_one_realization_id,
+                                figure=go.Figure(),
+                                config={
+                                    "displayModeBar": False,
+                                },
+                            ),
+                        ),
+                    ],
+                ),
+            ],
         ),
     ]

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
@@ -136,10 +136,11 @@ def _summary_graph_layout(
     return [
         wcc.Tabs(
             id="TAB",
-            value="custom",
+            value="tab-1",
             children=[
                 wcc.Tab(
                     label="End-state containment (all realizations)",
+                    value="tab-1",
                     children=[
                         html.Div(
                             wcc.Graph(
@@ -154,6 +155,7 @@ def _summary_graph_layout(
                 ),
                 wcc.Tab(
                     label="Containment over time (all realizations)",
+                    value="tab-2",
                     children=[
                         html.Div(
                             wcc.Graph(
@@ -168,6 +170,7 @@ def _summary_graph_layout(
                 ),
                 wcc.Tab(
                     label="Containment over time (one realization)",
+                    value="tab-3",
                     children=[
                         html.Div(
                             wcc.Graph(

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
@@ -29,7 +29,6 @@ class MapViewElement(ViewElementABC):
         TIME_PLOT_ONE_REAL = "time-plot-one-realization"
         BAR_PLOT_ORDER = "bar-plot-order"
         CONTAINMENT_COLORS = "containment-order"
-        CONTAINMENT_CHECKBOXES = "containment-checkboxes"
         SIZE_SLIDER = "size-slider"
         TOP_ELEMENT = "top-element"
         BOTTOM_ELEMENT = "bottom-element"
@@ -75,60 +74,28 @@ class MapViewElement(ViewElementABC):
                                 marks={0: ""},
                                 value=0,
                             ),
-                            id=self.register_component_unique_id(
-                                self.Ids.DATE_WRAPPER
-                            ),
+                            id=self.register_component_unique_id(self.Ids.DATE_WRAPPER),
                         ),
                     ],
                     style={
-                        "height": "44vh",
+                        "height": "43vh",
                     },
                 ),
                 wcc.Frame(
                     # id=get_uuid(LayoutElements.PLOT_VIEW),
-                    id=self.register_component_unique_id(
-                        self.Ids.BOTTOM_ELEMENT
-                    ),
+                    id=self.register_component_unique_id(self.Ids.BOTTOM_ELEMENT),
                     style={
-                        "height": "35vh",
+                        "height": "37vh",
                     },
                     children=[
                         html.Div(
                             _summary_graph_layout(
-                                self.register_component_unique_id(
-                                    self.Ids.BAR_PLOT
-                                ),
-                                self.register_component_unique_id(
-                                    self.Ids.TIME_PLOT
-                                ),
+                                self.register_component_unique_id(self.Ids.BAR_PLOT),
+                                self.register_component_unique_id(self.Ids.TIME_PLOT),
                                 self.register_component_unique_id(
                                     self.Ids.TIME_PLOT_ONE_REAL
                                 ),
                             )
-                        ),
-                        html.Div(
-                            dcc.RadioItems(
-                                options=[
-                                    {"label": "Sort by zones", "value": 0},
-                                    {
-                                        "label": "Sort by containment",
-                                        "value": 1,
-                                    },
-                                    {
-                                        "label": "Color by containment",
-                                        "value": 2,
-                                    },
-                                ],
-                                value=0,
-                                inline=True,
-                                id=self.register_component_unique_id(
-                                    self.Ids.CONTAINMENT_CHECKBOXES
-                                ),
-                            ),
-                            #style={
-                            #    "position": "absolute",
-                            #    "bottom": 0,
-                            #},
                         ),
                     ],
                 ),
@@ -136,15 +103,15 @@ class MapViewElement(ViewElementABC):
                     [
                         wcc.Slider(
                             id=self.register_component_unique_id(self.Ids.SIZE_SLIDER),
-                            min=20,
-                            max=60,
-                            step=1,
-                            value=35,
+                            min=1,
+                            max=79,
+                            step=2,
+                            value=37,
                             vertical=False,
                             marks={
-                                20: "Big map",
-                                35: "Standard",
-                                60: "Big plots",
+                                #1: "Top",
+                                37: "Drag to scale the size of the containment plots",
+                                #79: "Bottom",
                             },
                         ),
                     ],
@@ -154,7 +121,7 @@ class MapViewElement(ViewElementABC):
                 ),
             ],
             style={
-                #"flex": 3,
+                # "flex": 3,
                 "display": "flex",
                 "flexDirection": "column",
                 "height": "90vh",
@@ -173,7 +140,7 @@ def _summary_graph_layout(
             value="custom",
             children=[
                 wcc.Tab(
-                    label="End-state CO2 containment (all realizations)",
+                    label="End-state containment (all realizations)",
                     children=[
                         html.Div(
                             wcc.Graph(
@@ -187,7 +154,7 @@ def _summary_graph_layout(
                     ],
                 ),
                 wcc.Tab(
-                    label="CO2 containment over time (all realizations)",
+                    label="Containment over time (all realizations)",
                     children=[
                         html.Div(
                             wcc.Graph(
@@ -201,7 +168,7 @@ def _summary_graph_layout(
                     ],
                 ),
                 wcc.Tab(
-                    label="CO2 containment over time (one realization)",
+                    label="Containment over time (one realization)",
                     children=[
                         html.Div(
                             wcc.Graph(

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
@@ -30,6 +30,9 @@ class MapViewElement(ViewElementABC):
         BAR_PLOT_ORDER = "bar-plot-order"
         CONTAINMENT_COLORS = "containment-order"
         CONTAINMENT_CHECKBOXES = "containment-checkboxes"
+        SIZE_SLIDER = "size-slider"
+        TOP_ELEMENT = "top-element"
+        BOTTOM_ELEMENT = "bottom-element"
 
     def __init__(self, color_scales: List[Dict[str, Any]]) -> None:
         super().__init__()
@@ -40,6 +43,7 @@ class MapViewElement(ViewElementABC):
             [
                 wcc.Frame(
                     # id=self.register_component_unique_id(LayoutElements.MAP_VIEW),
+                    id=self.register_component_unique_id(self.Ids.TOP_ELEMENT),
                     color="white",
                     highlight=False,
                     children=[
@@ -57,8 +61,8 @@ class MapViewElement(ViewElementABC):
                                 ),
                             ],
                             style={
-                                "padding": "0.5vh",
-                                "height": "37vh",
+                                "padding": "1%",
+                                "height": "80%",
                                 "position": "relative",
                             },
                         ),
@@ -71,41 +75,89 @@ class MapViewElement(ViewElementABC):
                                 marks={0: ""},
                                 value=0,
                             ),
-                            id=self.register_component_unique_id(self.Ids.DATE_WRAPPER),
+                            id=self.register_component_unique_id(
+                                self.Ids.DATE_WRAPPER
+                            ),
                         ),
                     ],
                     style={
-                        "height": "45vh",
+                        "height": "44vh",
                     },
                 ),
                 wcc.Frame(
                     # id=get_uuid(LayoutElements.PLOT_VIEW),
-                    style={
-                        "height": "34vh",
-                    },
-                    children=_summary_graph_layout(
-                        self.register_component_unique_id(self.Ids.BAR_PLOT),
-                        self.register_component_unique_id(self.Ids.TIME_PLOT),
-                        self.register_component_unique_id(self.Ids.TIME_PLOT_ONE_REAL),
-                    ),
-                ),
-                dcc.RadioItems(
-                    options=[
-                        {"label": "Sort by zones", "value": 0},
-                        {"label": "Sort by containment", "value": 1},
-                        {"label": "Color by containment", "value": 2},
-                    ],
-                    value=0,
-                    inline=True,
                     id=self.register_component_unique_id(
-                        self.Ids.CONTAINMENT_CHECKBOXES
+                        self.Ids.BOTTOM_ELEMENT
                     ),
+                    style={
+                        "height": "35vh",
+                    },
+                    children=[
+                        html.Div(
+                            _summary_graph_layout(
+                                self.register_component_unique_id(
+                                    self.Ids.BAR_PLOT
+                                ),
+                                self.register_component_unique_id(
+                                    self.Ids.TIME_PLOT
+                                ),
+                                self.register_component_unique_id(
+                                    self.Ids.TIME_PLOT_ONE_REAL
+                                ),
+                            )
+                        ),
+                        html.Div(
+                            dcc.RadioItems(
+                                options=[
+                                    {"label": "Sort by zones", "value": 0},
+                                    {
+                                        "label": "Sort by containment",
+                                        "value": 1,
+                                    },
+                                    {
+                                        "label": "Color by containment",
+                                        "value": 2,
+                                    },
+                                ],
+                                value=0,
+                                inline=True,
+                                id=self.register_component_unique_id(
+                                    self.Ids.CONTAINMENT_CHECKBOXES
+                                ),
+                            ),
+                            #style={
+                            #    "position": "absolute",
+                            #    "bottom": 0,
+                            #},
+                        ),
+                    ],
+                ),
+                html.Div(
+                    [
+                        wcc.Slider(
+                            id=self.register_component_unique_id(self.Ids.SIZE_SLIDER),
+                            min=20,
+                            max=60,
+                            step=1,
+                            value=35,
+                            vertical=False,
+                            marks={
+                                20: "Big map",
+                                35: "Standard",
+                                60: "Big plots",
+                            },
+                        ),
+                    ],
+                    style={
+                        "width": "100%",
+                    },
                 ),
             ],
             style={
-                "flex": 3,
+                #"flex": 3,
                 "display": "flex",
                 "flexDirection": "column",
+                "height": "90vh",
             },
         )
 

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -344,7 +344,6 @@ class ViewSettings(SettingsGroupABC):
             Output("zone_col", "style"),
             Output("region_col", "style"),
             Output("both_col", "style"),
-            #Output("zone_region_header", "style"),
             Output(
                 self.component_unique_id(self.Ids.PHASEDROPDOWN).to_string(), "style"
             ),
@@ -354,7 +353,6 @@ class ViewSettings(SettingsGroupABC):
         )
         def hide_dropdowns(view: str) -> List[Dict[str, str]]:
             if view != ContainmentViews.CONTAINMENTSPLIT:
-                #return [{"display": "none"}] * 4 + [{}]
                 return [{"display": "none"}] * 3 + [{}]
             disp_zone = "flex" if self._has_zones else "none"
             disp_region = "flex" if self._has_regions else "none"
@@ -371,12 +369,13 @@ class ViewSettings(SettingsGroupABC):
                     "flex-direction": "column",
                 },
                 {"display": disp_either},
-                #{"display": disp_either},
                 {"display": "none"},
             ]
 
         @callback(
-            Output(self.component_unique_id(self.Ids.COLOR_OPTIONS).to_string(), "disabled"),
+            Output(
+                self.component_unique_id(self.Ids.COLOR_OPTIONS).to_string(), "disabled"
+            ),
             Input(
                 self.component_unique_id(self.Ids.CONTAINMENT_VIEW).to_string(), "value"
             ),
@@ -659,16 +658,9 @@ class GraphSelectorsLayout(wcc.Selectors):
                         "margin-bottom": "1px",
                     },
                 ),
-                #html.Div(
-                #    header,
-                #    id="zone_region_header",
-                #    style={"display": disp},
-                #),
                 html.Div(
                     [
                         html.Div(
-                            #([] if only_zone else ["zone"])
-                            #+ [
                             [
                                 "Specific zone",
                                 wcc.Dropdown(
@@ -684,8 +676,6 @@ class GraphSelectorsLayout(wcc.Selectors):
                             },
                         ),
                         html.Div(
-                            #([] if only_region else ["region"])
-                            #+ [
                             [
                                 "Specific region",
                                 wcc.Dropdown(
@@ -706,7 +696,6 @@ class GraphSelectorsLayout(wcc.Selectors):
                 ),
                 html.Div(
                     [
-                        #"Containment for specific phase",
                         "Specific phase",
                         wcc.Dropdown(
                             options=list(PhaseOptions),
@@ -729,8 +718,7 @@ class GraphSelectorsLayout(wcc.Selectors):
                     value=2,
                     clearable=False,
                 ),
-                "Fix y-limits between realizations:\n"
-                "Minimum",
+                "Fix y-limits between realizations:\nMinimum",
                 html.Div(
                     [
                         dcc.Input(id=y_min_ids[0], type="number"),

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -47,12 +47,18 @@ class ViewSettings(SettingsGroupABC):
         Y_MAX_GRAPH = "y-max-graph"
         Y_MIN_AUTO_GRAPH = "y-min-auto-graph"
         Y_MAX_AUTO_GRAPH = "y-max-auto-graph"
+        COLOR_BY = "color-by"
+        MARK_BY = "mark-by"
+        SORT_PLOT = "sort-plot"
         ZONE = "zone"
+        ZONE_COL = "zone-column"
+        REGION_COL = "region-column"
+        ZONE_REGION = "zone-and-region"
         REGION = "region"
         PHASE = "phase"
-        PHASE_DROPDOWN = "phase_drop_down"
+        PHASE_MENU = "phase-menu"
         CONTAINMENT = "containment"
-        CONTAINMENT_DROPDOWN = "containment_drop_down"
+        CONTAINMENT_MENU = "containment-menu"
 
         PLUME_THRESHOLD = "plume-threshold"
         PLUME_SMOOTHING = "plume-smoothing"
@@ -128,12 +134,18 @@ class ViewSettings(SettingsGroupABC):
                     self.register_component_unique_id(self.Ids.Y_MAX_AUTO_GRAPH),
                 ],
                 [
+                    self.register_component_unique_id(self.Ids.COLOR_BY),
+                    self.register_component_unique_id(self.Ids.MARK_BY),
+                    self.register_component_unique_id(self.Ids.SORT_PLOT),
                     self.register_component_unique_id(self.Ids.ZONE),
+                    self.register_component_unique_id(self.Ids.ZONE_COL),
                     self.register_component_unique_id(self.Ids.REGION),
+                    self.register_component_unique_id(self.Ids.REGION_COL),
+                    self.register_component_unique_id(self.Ids.ZONE_REGION),
                     self.register_component_unique_id(self.Ids.PHASE),
-                    self.register_component_unique_id(self.Ids.PHASE_DROPDOWN),
+                    self.register_component_unique_id(self.Ids.PHASE_MENU),
                     self.register_component_unique_id(self.Ids.CONTAINMENT),
-                    self.register_component_unique_id(self.Ids.CONTAINMENT_DROPDOWN),
+                    self.register_component_unique_id(self.Ids.CONTAINMENT_MENU),
                 ],
                 self._has_zones,
                 self._has_regions,
@@ -309,20 +321,18 @@ class ViewSettings(SettingsGroupABC):
             return False
 
         @callback(
-            Output("mark_by", "options"),
-            Output("mark_by", "value"),
-            Output("zone_col", "style"),
-            Output("region_col", "style"),
-            Output("both_col", "style"),
+            Output(self.component_unique_id(self.Ids.MARK_BY).to_string(), "options"),
+            Output(self.component_unique_id(self.Ids.MARK_BY).to_string(), "value"),
+            Output(self.component_unique_id(self.Ids.ZONE_COL).to_string(), "style"),
+            Output(self.component_unique_id(self.Ids.REGION_COL).to_string(), "style"),
+            Output(self.component_unique_id(self.Ids.ZONE_REGION).to_string(), "style"),
+            Output(self.component_unique_id(self.Ids.PHASE_MENU).to_string(), "style"),
             Output(
-                self.component_unique_id(self.Ids.PHASE_DROPDOWN).to_string(), "style"
-            ),
-            Output(
-                self.component_unique_id(self.Ids.CONTAINMENT_DROPDOWN).to_string(),
+                self.component_unique_id(self.Ids.CONTAINMENT_MENU).to_string(),
                 "style",
             ),
-            Input("color_by", "value"),
-            Input("mark_by", "value"),
+            Input(self.component_unique_id(self.Ids.COLOR_BY).to_string(), "value"),
+            Input(self.component_unique_id(self.Ids.MARK_BY).to_string(), "value"),
         )
         def organize_color_and_mark_menus(
             color_choice: str,
@@ -628,11 +638,10 @@ class GraphSelectorsLayout(wcc.Selectors):
                                 wcc.Dropdown(
                                     options=color_options,
                                     value="containment",
-                                    id="color_by",
+                                    id=containment_ids[0],
                                     clearable=False,
                                 ),
                             ],
-                            id="colby",
                             style={
                                 "width": "50%",
                                 "flex-direction": "column",
@@ -642,18 +651,16 @@ class GraphSelectorsLayout(wcc.Selectors):
                             [
                                 "Mark by",
                                 wcc.Dropdown(
-                                    id="mark_by",
+                                    id=containment_ids[1],
                                     clearable=False,
                                 ),
                             ],
-                            id="markby",
                             style={
                                 "width": "50%",
                                 "flex-direction": "column",
                             },
                         ),
                     ],
-                    id="colbymarkby",
                     style={
                         "display": "flex",  # disp,
                         "flex-direction": "row",
@@ -667,7 +674,7 @@ class GraphSelectorsLayout(wcc.Selectors):
                         dcc.RadioItems(
                             options=["color", "marking"],
                             value="color",
-                            id="sorting",
+                            id=containment_ids[2],
                             inline=True,
                         ),
                     ],
@@ -684,11 +691,11 @@ class GraphSelectorsLayout(wcc.Selectors):
                             [
                                 "Specific zone",
                                 wcc.Dropdown(
-                                    id=containment_ids[0],
+                                    id=containment_ids[3],
                                     clearable=False,
                                 ),
                             ],
-                            id="zone_col",
+                            id=containment_ids[4],
                             style={
                                 "width": "50%" if has_regions else "100%",
                                 "display": disp_zone,
@@ -699,11 +706,11 @@ class GraphSelectorsLayout(wcc.Selectors):
                             [
                                 "Specific region",
                                 wcc.Dropdown(
-                                    id=containment_ids[1],
+                                    id=containment_ids[5],
                                     clearable=False,
                                 ),
                             ],
-                            id="region_col",
+                            id=containment_ids[6],
                             style={
                                 "width": "50%" if has_zones else "100%",
                                 "display": disp_region,
@@ -711,7 +718,7 @@ class GraphSelectorsLayout(wcc.Selectors):
                             },
                         ),
                     ],
-                    id="both_col",
+                    id=containment_ids[7],
                     style={"display": disp},
                 ),
                 html.Div(
@@ -725,10 +732,10 @@ class GraphSelectorsLayout(wcc.Selectors):
                             ],
                             value="total",
                             clearable=False,
-                            id=containment_ids[2],
+                            id=containment_ids[8],
                         ),
                     ],
-                    id=containment_ids[3],
+                    id=containment_ids[9],
                     style={"display": "none"},
                 ),
                 html.Div(
@@ -743,10 +750,10 @@ class GraphSelectorsLayout(wcc.Selectors):
                             ],
                             value="total",
                             clearable=False,
-                            id=containment_ids[4],
+                            id=containment_ids[10],
                         ),
                     ],
-                    id=containment_ids[5],
+                    id=containment_ids[11],
                     style={"display": "none"},
                 ),
                 html.Div(
@@ -954,7 +961,6 @@ def _make_styles(
     both_style = {"display": "none"}
     phase_style = {"display": "none"}
     containment_style = {"display": "none"}
-
     if color_choice == "containment":
         if mark_choice == "phase":
             zone_style = {


### PR DESCRIPTION
Split containment plots into 3 tabs so that each has increased size and readability.

Add menus to select which property (containment status, zone, region) that is used to determine the colors and which property (containment status, zone, region, phase) that is used to determine the marking in the containment plots.

Add slider to adjust relative size between the map and the containment plots.

Minor visual improvements.