### PR TITLE
Migration time for AMFG

### DIFF
--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -359,7 +359,10 @@ class CO2Leakage(WebvizPluginABC):
             Input(self._settings_component(ViewSettings.Ids.PROPERTY), "value"),
         )
         def toggle_date_slider(attribute: str) -> Dict[str, str]:
-            if MapAttribute(attribute) == MapAttribute.MIGRATION_TIME:
+            if MapAttribute(attribute) in [
+                MapAttribute.MIGRATION_TIME_SGAS,
+                MapAttribute.MIGRATION_TIME_AMFG,
+            ]:
                 return {"display": "none"}
             return {}
 

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -134,10 +134,15 @@ def derive_surface_address(
             threshold=contour_data["threshold"] if contour_data else 0.0,
             smoothing=contour_data["smoothing"] if contour_data else 0.0,
         )
-    date = None if attribute in [
-        MapAttribute.MIGRATION_TIME_SGAS,
-        MapAttribute.MIGRATION_TIME_AMFG,
-    ] else date
+    date = (
+        None
+        if attribute
+        in [
+            MapAttribute.MIGRATION_TIME_SGAS,
+            MapAttribute.MIGRATION_TIME_AMFG,
+        ]
+        else date
+    )
     if len(realization) == 1:
         return SimulatedSurfaceAddress(
             attribute=map_attribute_names[attribute],

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -86,7 +86,9 @@ class SurfaceData:
             visualization_info,
             map_attribute_names,
         )
-        assert surf_meta is not None  # Should not occur
+        if surf_meta is None:  # Surface file does not exist
+            return None, None
+        assert isinstance(img_url, str)
         value_range = (
             0.0 if np.ma.is_masked(surf_meta.val_min) else surf_meta.val_min,
             0.0 if np.ma.is_masked(surf_meta.val_max) else surf_meta.val_max,
@@ -132,7 +134,10 @@ def derive_surface_address(
             threshold=contour_data["threshold"] if contour_data else 0.0,
             smoothing=contour_data["smoothing"] if contour_data else 0.0,
         )
-    date = None if attribute == MapAttribute.MIGRATION_TIME else date
+    date = None if attribute in [
+        MapAttribute.MIGRATION_TIME_SGAS,
+        MapAttribute.MIGRATION_TIME_AMFG,
+    ] else date
     if len(realization) == 1:
         return SimulatedSurfaceAddress(
             attribute=map_attribute_names[attribute],
@@ -151,7 +156,10 @@ def derive_surface_address(
 
 def readable_name(attribute: MapAttribute) -> str:
     unit = ""
-    if attribute == MapAttribute.MIGRATION_TIME:
+    if attribute in [
+        MapAttribute.MIGRATION_TIME_SGAS,
+        MapAttribute.MIGRATION_TIME_AMFG,
+    ]:
         unit = " [year]"
     elif attribute in (MapAttribute.AMFG_PLUME, MapAttribute.SGAS_PLUME):
         unit = " [# real.]"
@@ -198,7 +206,10 @@ def get_plume_polygon(
 
 
 def _find_legend_title(attribute: MapAttribute, unit: str) -> str:
-    if attribute == MapAttribute.MIGRATION_TIME:
+    if attribute in [
+        MapAttribute.MIGRATION_TIME_SGAS,
+        MapAttribute.MIGRATION_TIME_AMFG,
+    ]:
         return "years"
     if attribute in [MapAttribute.MASS, MapAttribute.DISSOLVED, MapAttribute.FREE]:
         return unit

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -4,7 +4,8 @@ from webviz_config.utils import StrEnum
 
 
 class MapAttribute(Enum):
-    MIGRATION_TIME = "Migration Time"
+    MIGRATION_TIME_SGAS = "Migration time (SGAS)"
+    MIGRATION_TIME_AMFG = "Migration time (AMFG)"
     MAX_SGAS = "Maximum SGAS"
     MAX_AMFG = "Maximum AMFG"
     SGAS_PLUME = "Plume (SGAS)"

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
@@ -35,7 +35,8 @@ def init_map_attribute_names(
     if mapping is None:
         # Based on name convention of xtgeoapp_grd3dmaps:
         return {
-            MapAttribute.MIGRATION_TIME: "migrationtime",
+            MapAttribute.MIGRATION_TIME_SGAS: "migrationtime_sgas",
+            MapAttribute.MIGRATION_TIME_AMFG: "migrationtime_amfg",
             MapAttribute.MAX_SGAS: "max_sgas",
             MapAttribute.MAX_AMFG: "max_amfg",
             MapAttribute.MASS: "co2-mass-total",

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -44,7 +45,7 @@ def publish_and_get_surface_metadata(
     address: Union[SurfaceAddress, TruncatedSurfaceAddress],
     visualization_info: Dict[str, Any],
     map_attribute_names: Dict[MapAttribute, str],
-) -> Tuple[Optional[SurfaceImageMeta], str, Optional[Any]]:
+) -> Tuple[Optional[SurfaceImageMeta], Optional[str], Optional[Any]]:
     if isinstance(address, TruncatedSurfaceAddress):
         return _publish_and_get_truncated_surface_metadata(server, provider, address)
     provider_id: str = provider.provider_id()
@@ -53,9 +54,13 @@ def publish_and_get_surface_metadata(
     summed_mass = None
     if not surf_meta:
         # This means we need to compute the surface
-        surface = provider.get_surface(address)
+        try:
+            surface = provider.get_surface(address)
+        except ValueError:
+            surface = None
         if not surface:
-            raise ValueError(f"Could not get surface for address: {address}")
+            warnings.warn(f"Could not find surface file with properties: {address}")
+            return None, None, None
         if address.attribute in [
             map_attribute_names[MapAttribute.MASS],
             map_attribute_names[MapAttribute.FREE],
@@ -64,7 +69,10 @@ def publish_and_get_surface_metadata(
             surface.values = surface.values / SCALE_DICT[visualization_info["unit"]]
         summed_mass = np.ma.sum(surface.values)
         if (
-            address.attribute != map_attribute_names[MapAttribute.MIGRATION_TIME]
+            address.attribute not in [
+                map_attribute_names[MapAttribute.MIGRATION_TIME_SGAS],
+                map_attribute_names[MapAttribute.MIGRATION_TIME_AMFG],
+            ]
             and visualization_info["threshold"] >= 0
         ):
             surface.operation("elile", visualization_info["threshold"])

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
@@ -69,7 +69,8 @@ def publish_and_get_surface_metadata(
             surface.values = surface.values / SCALE_DICT[visualization_info["unit"]]
         summed_mass = np.ma.sum(surface.values)
         if (
-            address.attribute not in [
+            address.attribute
+            not in [
                 map_attribute_names[MapAttribute.MIGRATION_TIME_SGAS],
                 map_attribute_names[MapAttribute.MIGRATION_TIME_AMFG],
             ]

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -190,8 +190,8 @@ class ViewSettings(SettingsGroupABC):
             prop_name = property_origin(MapAttribute(prop), self._map_attribute_names)
             surfaces = surface_provider.surface_names_for_attribute(prop_name)
             if len(surfaces) == 0:
-                warning = (f"Surface not found for property: {prop}.\n"
-                           f"Expected name: <formation>--{prop_name}")
+                warning = f"Surface not found for property: {prop}.\n"
+                warning += f"Expected name: <formation>--{prop_name}"
                 if prop not in [
                     MapAttribute.MIGRATION_TIME_SGAS,
                     MapAttribute.MIGRATION_TIME_AMFG,

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -190,10 +190,14 @@ class ViewSettings(SettingsGroupABC):
             prop_name = property_origin(MapAttribute(prop), self._map_attribute_names)
             surfaces = surface_provider.surface_names_for_attribute(prop_name)
             if len(surfaces) == 0:
-                warnings.warn(
-                    f"Surface not found for property: {prop}.\n"
-                    f"Expected name: <formation>--{prop_name}--<date>.gri"
-                )
+                warning = (f"Surface not found for property: {prop}.\n"
+                           f"Expected name: <formation>--{prop_name}")
+                if prop not in [
+                    MapAttribute.MIGRATION_TIME_SGAS,
+                    MapAttribute.MIGRATION_TIME_AMFG,
+                ]:
+                    warning += "--<date>"
+                warnings.warn(warning + ".gri")
             # Formation names
             formations = [{"label": v.title(), "value": v} for v in surfaces]
             picked_formation = None
@@ -246,7 +250,10 @@ class ViewSettings(SettingsGroupABC):
             Input(self.component_unique_id(self.Ids.PROPERTY).to_string(), "value"),
         )
         def set_visualization_threshold(attribute: str) -> bool:
-            return MapAttribute(attribute) == MapAttribute.MIGRATION_TIME
+            return MapAttribute(attribute) in [
+                MapAttribute.MIGRATION_TIME_SGAS,
+                MapAttribute.MIGRATION_TIME_AMFG,
+            ]
 
         @callback(
             Output(
@@ -336,14 +343,7 @@ class ViewSettings(SettingsGroupABC):
         def organize_color_and_mark_menus(
             color_choice: str,
             mark_choice: str,
-        ) -> Tuple[
-            List[Dict[str, str]],
-            str,
-            Dict[str, str],
-            Dict[str, str],
-            Dict[str, str],
-            Dict[str, str],
-        ]:
+        ) -> Tuple[List[Dict], str, Dict, Dict, Dict, Dict]:
             mark_options = [
                 {"label": "Phase", "value": "phase"},
                 {"label": "None", "value": "none"},
@@ -501,7 +501,7 @@ class MapSelectorLayout(wcc.Selectors):
                         wcc.Dropdown(
                             id=property_id,
                             options=_compile_property_options(),
-                            value=MapAttribute.MIGRATION_TIME.value,
+                            value=MapAttribute.MIGRATION_TIME_SGAS.value,
                             clearable=False,
                         ),
                         "Statistic",
@@ -862,8 +862,8 @@ def _compile_property_options() -> List[Dict[str, Any]]:
             "disabled": True,
         },
         {
-            "label": MapAttribute.MIGRATION_TIME.value,
-            "value": MapAttribute.MIGRATION_TIME.value,
+            "label": MapAttribute.MIGRATION_TIME_SGAS.value,
+            "value": MapAttribute.MIGRATION_TIME_SGAS.value,
         },
         {"label": MapAttribute.MAX_SGAS.value, "value": MapAttribute.MAX_SGAS.value},
         {
@@ -874,6 +874,10 @@ def _compile_property_options() -> List[Dict[str, Any]]:
             "label": html.Span(["AMFG:"], style={"text-decoration": "underline"}),
             "value": "",
             "disabled": True,
+        },
+        {
+            "label": MapAttribute.MIGRATION_TIME_AMFG.value,
+            "value": MapAttribute.MIGRATION_TIME_AMFG.value,
         },
         {"label": MapAttribute.MAX_AMFG.value, "value": MapAttribute.MAX_AMFG.value},
         {


### PR DESCRIPTION
Adds support for migration time maps for the AMFG property. Files must be named "<formation>--migrationtime_amfg.gri". Migration time maps for SGAS must now be named "<formation>--migrationtime_sgas.gri" instead of just "<formation>--migrationtime.gri".
