### PR TITLE
Fix generation of UNSMRY plots

### DIFF
--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -37,7 +37,7 @@ from webviz_subsurface.plugins._co2_leakage._utilities.initialization import (
     init_map_attribute_names,
     init_menu_options,
     init_surface_providers,
-    init_table_provider,
+    init_unsmry_data_providers,
     init_well_pick_provider,
     process_files,
     init_containment_data_providers,
@@ -155,7 +155,7 @@ class CO2Leakage(WebvizPluginABC):
                 plume_actual_volume_relpath,
             )
             self._unsmry_providers = (
-                init_table_provider(
+                init_unsmry_data_providers(
                     ensemble_paths,
                     unsmry_relpath,
                 )

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -172,6 +172,7 @@ class CO2Leakage(WebvizPluginABC):
                 ensemble_paths,
                 self._co2_table_providers,
                 self._co2_actual_volume_table_providers,
+                self._unsmry_providers,
             )
         except Exception as err:
             self._error_message = f"Plugin initialization failed: {err}"
@@ -327,6 +328,8 @@ class CO2Leakage(WebvizPluginABC):
                             co2_scale,
                             self._co2_table_providers[ensemble],
                         )
+                        figs[1] = None
+                        figs[2] = None
                 else:
                     LOGGER.warning(
                         """UNSMRY file has not been specified as input.

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -323,12 +323,11 @@ class CO2Leakage(WebvizPluginABC):
             elif source == GraphSource.UNSMRY:
                 if self._unsmry_providers is not None:
                     if ensemble in self._unsmry_providers:
-                        u_figs = generate_unsmry_figures(
+                        figs[0] = generate_unsmry_figures(
                             self._unsmry_providers[ensemble],
                             co2_scale,
                             self._co2_table_providers[ensemble],
                         )
-                        figs = list(u_figs)
                 else:
                     LOGGER.warning(
                         """UNSMRY file has not been specified as input.

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -154,13 +154,9 @@ class CO2Leakage(WebvizPluginABC):
                 ensemble_paths,
                 plume_actual_volume_relpath,
             )
-            self._unsmry_providers = (
-                init_unsmry_data_providers(
-                    ensemble_paths,
-                    unsmry_relpath,
-                )
-                if unsmry_relpath is not None
-                else None
+            self._unsmry_providers = init_unsmry_data_providers(
+                ensemble_paths,
+                unsmry_relpath,
             )
             # Well picks
             self._well_pick_provider = init_well_pick_provider(
@@ -323,12 +319,12 @@ class CO2Leakage(WebvizPluginABC):
             elif source == GraphSource.UNSMRY:
                 if self._unsmry_providers is not None:
                     if ensemble in self._unsmry_providers:
-                        figs[0] = generate_unsmry_figures(
+                        figs[0] = None
+                        figs[1] = generate_unsmry_figures(
                             self._unsmry_providers[ensemble],
                             co2_scale,
                             self._co2_table_providers[ensemble],
                         )
-                        figs[1] = None
                         figs[2] = None
                 else:
                     LOGGER.warning(

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -40,6 +40,7 @@ from webviz_subsurface.plugins._co2_leakage._utilities.initialization import (
     init_table_provider,
     init_well_pick_provider,
     process_files,
+    init_containment_data_providers,
 )
 from webviz_subsurface.plugins._co2_leakage.views.mainview.mainview import (
     MainView,
@@ -145,11 +146,11 @@ class CO2Leakage(WebvizPluginABC):
                 for ens in ensembles
             }
             # CO2 containment
-            self._co2_table_providers = init_table_provider(
+            self._co2_table_providers = init_containment_data_providers(
                 ensemble_paths,
                 plume_mass_relpath,
             )
-            self._co2_actual_volume_table_providers = init_table_provider(
+            self._co2_actual_volume_table_providers = init_containment_data_providers(
                 ensemble_paths,
                 plume_actual_volume_relpath,
             )
@@ -171,8 +172,6 @@ class CO2Leakage(WebvizPluginABC):
                 ensemble_paths,
                 self._co2_table_providers,
                 self._co2_actual_volume_table_providers,
-                plume_mass_relpath,
-                plume_actual_volume_relpath,
             )
         except Exception as err:
             self._error_message = f"Plugin initialization failed: {err}"

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -319,13 +319,13 @@ class CO2Leakage(WebvizPluginABC):
             elif source == GraphSource.UNSMRY:
                 if self._unsmry_providers is not None:
                     if ensemble in self._unsmry_providers:
-                        figs[0] = None
+                        figs[0] = go.Figure()
                         figs[1] = generate_unsmry_figures(
                             self._unsmry_providers[ensemble],
                             co2_scale,
                             self._co2_table_providers[ensemble],
                         )
-                        figs[2] = None
+                        figs[2] = go.Figure()
                 else:
                     LOGGER.warning(
                         """UNSMRY file has not been specified as input.

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -435,15 +435,11 @@ def generate_unsmry_figures(
     table_provider_unsmry: EnsembleTableProvider,
     co2_mass_scale: Union[Co2MassScale, Co2VolumeScale],
     table_provider_containment: EnsembleTableProvider,
-) -> Tuple[go.Figure]:
-    return (
-        generate_summary_figure(
-            table_provider_unsmry,
-            table_provider_unsmry.realizations(),
-            co2_mass_scale,
-            table_provider_containment,
-            table_provider_containment.realizations(),
-        ),
+) -> go.Figure:
+    return generate_summary_figure(
+        table_provider_unsmry,
+        co2_mass_scale,
+        table_provider_containment,
     )
 
 

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -43,6 +43,9 @@ from webviz_subsurface.plugins._co2_leakage._utilities.surface_publishing import
     TruncatedSurfaceAddress,
     publish_and_get_surface_metadata,
 )
+from webviz_subsurface.plugins._co2_leakage._utilities.unsmry_data_provider import (
+    UnsmryDataProvider
+)
 from webviz_subsurface.plugins._map_viewer_fmu._tmp_well_pick_provider import (
     WellPickProvider,
 )
@@ -413,13 +416,13 @@ def generate_containment_figures(
     try:
         fig0 = generate_co2_volume_figure(
             table_provider,
-            table_provider.realizations(),
+            table_provider.realizations,
             co2_scale,
             containment_info,
         )
         fig1 = generate_co2_time_containment_figure(
             table_provider,
-            table_provider.realizations(),
+            table_provider.realizations,
             co2_scale,
             containment_info,
         )
@@ -433,7 +436,7 @@ def generate_containment_figures(
 
 
 def generate_unsmry_figures(
-    table_provider_unsmry: EnsembleTableProvider,
+    table_provider_unsmry: UnsmryDataProvider,
     co2_mass_scale: Union[Co2MassScale, Co2VolumeScale],
     table_provider_containment: ContainmentDataProvider,
 ) -> go.Figure:

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -28,6 +28,7 @@ from webviz_subsurface.plugins._co2_leakage._utilities.co2volume import (
     generate_co2_time_containment_one_realization_figure,
     generate_co2_volume_figure,
 )
+from webviz_subsurface.plugins._co2_leakage._utilities.containment_data_provider import ContainmentDataProvider
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     Co2MassScale,
     Co2VolumeScale,
@@ -403,7 +404,7 @@ def create_map_layers(
 
 
 def generate_containment_figures(
-    table_provider: EnsembleTableProvider,
+    table_provider: ContainmentDataProvider,
     co2_scale: Union[Co2MassScale, Co2VolumeScale],
     realization: int,
     y_limits: List[Optional[float]],
@@ -434,7 +435,7 @@ def generate_containment_figures(
 def generate_unsmry_figures(
     table_provider_unsmry: EnsembleTableProvider,
     co2_mass_scale: Union[Co2MassScale, Co2VolumeScale],
-    table_provider_containment: EnsembleTableProvider,
+    table_provider_containment: ContainmentDataProvider,
 ) -> go.Figure:
     return generate_summary_figure(
         table_provider_unsmry,

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/containment_data_provider.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/containment_data_provider.py
@@ -1,0 +1,93 @@
+from functools import lru_cache
+from typing import TypedDict, List, Union
+
+import pandas as pd
+
+from webviz_subsurface._providers import EnsembleTableProvider
+from webviz_subsurface.plugins._co2_leakage._utilities.generic import Co2MassScale, Co2VolumeScale
+
+
+class MenuOptions(TypedDict):
+    zones: List[str]
+    regions: List[str]
+    phases: List[str]
+
+
+class ContainmentDataProvider:
+    def __init__(self, table_provider: EnsembleTableProvider):
+        # TODO: perform validation
+        self._provider = table_provider
+
+    @property
+    def realizations(self):
+        return self._provider.realizations()
+
+    def get_menu_options(self) -> MenuOptions:
+        # TODO: set these on __init__ such that validation can be done as soon as possible
+
+        col_names = self._provider.column_names()
+        realization = self._provider.realizations()[0]
+        df = self._provider.get_column_data(col_names, [realization])
+        required_columns = ["date", "amount", "phase", "containment", "zone", "region"]
+        missing_columns = [col for col in required_columns if col not in col_names]
+        if len(missing_columns) > 0:
+            raise KeyError(
+                f"Missing expected columns {', '.join(missing_columns)}"
+                f" in realization {realization} (and possibly other csv-files). "
+                f"Provided files are likely from an old version of ccs-scripts."
+            )
+        zones = ["all"]
+        for zone in list(df["zone"]):
+            if zone not in zones:
+                zones.append(zone)
+        regions = ["all"]
+        for region in list(df["region"]):
+            if region not in regions:
+                regions.append(region)
+        if "free_gas" in list(df["phase"]):
+            phases = ["total", "free_gas", "trapped_gas", "aqueous"]
+        else:
+            phases = ["total", "gas", "aqueous"]
+        return {
+            "zones": zones if len(zones) > 1 else [],
+            "regions": regions if len(regions) > 1 else [],
+            "phases": phases,
+        }
+
+    def extract_dataframe(
+        self,
+        realization: int,
+        scale: Union[Co2MassScale, Co2VolumeScale]
+    ) -> pd.DataFrame:
+        df = self._provider.get_column_data(self._provider.column_names(), [realization])
+        scale_factor = self._find_scale_factor(scale)
+        if scale_factor == 1.0:
+            return df
+        df["amount"] /= scale_factor
+        return df
+
+    def extract_condensed_dataframe(
+        self,
+        co2_scale: Union[Co2MassScale, Co2VolumeScale],
+    ) -> pd.DataFrame:
+        df = self._provider.get_column_data(self._provider.column_names())
+        df = df[(df["zone"] == "all") & (df["region"] == "all")]
+        if co2_scale == Co2MassScale.MTONS:
+            df["amount"] = df["amount"] / 1e9
+        elif co2_scale == Co2MassScale.NORMALIZE:
+            df["amount"] = df["amount"] / df["total"].max()
+        return df
+
+    @lru_cache
+    def _find_scale_factor(
+        self,
+        scale: Union[Co2MassScale, Co2VolumeScale],
+    ) -> float:
+        if scale in (Co2MassScale.KG, Co2VolumeScale.CUBIC_METERS):
+            return 1.0
+        if scale in (Co2MassScale.MTONS, Co2VolumeScale.BILLION_CUBIC_METERS):
+            return 1e9
+        if scale in (Co2MassScale.NORMALIZE, Co2VolumeScale.NORMALIZE):
+            df = self._provider.get_column_data(["total"])
+            return df["total"].max()
+        return 1.0

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/containment_data_provider.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/containment_data_provider.py
@@ -1,58 +1,32 @@
-from functools import lru_cache
-from typing import TypedDict, List, Union
+from typing import Union
 
 import pandas as pd
 
 from webviz_subsurface._providers import EnsembleTableProvider
-from webviz_subsurface.plugins._co2_leakage._utilities.generic import Co2MassScale, Co2VolumeScale
+from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
+    Co2MassScale,
+    Co2VolumeScale,
+    MenuOptions,
+)
 
 
-class MenuOptions(TypedDict):
-    zones: List[str]
-    regions: List[str]
-    phases: List[str]
+class ContainmentDataValidationError(Exception):
+    pass
 
 
 class ContainmentDataProvider:
     def __init__(self, table_provider: EnsembleTableProvider):
-        # TODO: perform validation
+        ContainmentDataProvider._validate(table_provider)
         self._provider = table_provider
+        self._menu_options = ContainmentDataProvider._get_menu_options(self._provider)
+
+    @property
+    def menu_options(self) -> MenuOptions:
+        return self._menu_options
 
     @property
     def realizations(self):
         return self._provider.realizations()
-
-    def get_menu_options(self) -> MenuOptions:
-        # TODO: set these on __init__ such that validation can be done as soon as possible
-
-        col_names = self._provider.column_names()
-        realization = self._provider.realizations()[0]
-        df = self._provider.get_column_data(col_names, [realization])
-        required_columns = ["date", "amount", "phase", "containment", "zone", "region"]
-        missing_columns = [col for col in required_columns if col not in col_names]
-        if len(missing_columns) > 0:
-            raise KeyError(
-                f"Missing expected columns {', '.join(missing_columns)}"
-                f" in realization {realization} (and possibly other csv-files). "
-                f"Provided files are likely from an old version of ccs-scripts."
-            )
-        zones = ["all"]
-        for zone in list(df["zone"]):
-            if zone not in zones:
-                zones.append(zone)
-        regions = ["all"]
-        for region in list(df["region"]):
-            if region not in regions:
-                regions.append(region)
-        if "free_gas" in list(df["phase"]):
-            phases = ["total", "free_gas", "trapped_gas", "aqueous"]
-        else:
-            phases = ["total", "gas", "aqueous"]
-        return {
-            "zones": zones if len(zones) > 1 else [],
-            "regions": regions if len(regions) > 1 else [],
-            "phases": phases,
-        }
 
     def extract_dataframe(
         self,
@@ -71,14 +45,13 @@ class ContainmentDataProvider:
         co2_scale: Union[Co2MassScale, Co2VolumeScale],
     ) -> pd.DataFrame:
         df = self._provider.get_column_data(self._provider.column_names())
-        df = df[(df["zone"] == "all") & (df["region"] == "all")]
+        df = df.loc[(df["zone"] == "all") & (df["region"] == "all")]
         if co2_scale == Co2MassScale.MTONS:
-            df["amount"] = df["amount"] / 1e9
+            df.loc[:, "amount"] /= 1e9
         elif co2_scale == Co2MassScale.NORMALIZE:
-            df["amount"] = df["amount"] / df["total"].max()
+            df.loc[:, "amount"] /= df["amount"].max()
         return df
 
-    @lru_cache
     def _find_scale_factor(
         self,
         scale: Union[Co2MassScale, Co2VolumeScale],
@@ -88,6 +61,46 @@ class ContainmentDataProvider:
         if scale in (Co2MassScale.MTONS, Co2VolumeScale.BILLION_CUBIC_METERS):
             return 1e9
         if scale in (Co2MassScale.NORMALIZE, Co2VolumeScale.NORMALIZE):
-            df = self._provider.get_column_data(["total"])
-            return df["total"].max()
+            df = self._provider.get_column_data(["amount"])
+            return df["amount"].max()
         return 1.0
+
+    @staticmethod
+    def _get_menu_options(provider: EnsembleTableProvider) -> MenuOptions:
+        col_names = provider.column_names()
+        realization = provider.realizations()[0]
+        df = provider.get_column_data(col_names, [realization])
+        zones = ["all"]
+        for zone in list(df["zone"]):
+            if zone not in zones:
+                zones.append(zone)
+        regions = ["all"]
+        for region in list(df["region"]):
+            if region not in regions:
+                regions.append(region)
+        if "free_gas" in list(df["phase"]):
+            phases = ["total", "free_gas", "trapped_gas", "aqueous"]
+        else:
+            phases = ["total", "gas", "aqueous"]
+        return {
+            "zones": zones if len(zones) > 1 else [],
+            "regions": regions if len(regions) > 1 else [],
+            "phases": phases,
+        }
+
+    @staticmethod
+    def _validate(provider: EnsembleTableProvider):
+        col_names = provider.column_names()
+        required_columns = ["date", "amount", "phase", "containment", "zone", "region"]
+        missing_columns = [col for col in required_columns if col not in col_names]
+        realization = provider.realizations()[0]
+        if len(missing_columns) == 0:
+            return
+        raise ContainmentDataValidationError(
+            f"EnsembleTableProvider validation error for provider {provider} in "
+            f"realization {realization} (and possibly other csv-files).\n"
+            f"  Expected columns: {', '.join(missing_columns)}\n"
+            f"  Found columns: {', '.join(col_names)}\n"
+            f"  (Missing columns: {', '.join(missing_columns)})"
+            f"Provided files are possibly from an outdated version of ccs-scripts?"
+        )

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -1,3 +1,5 @@
+from typing import TypedDict, List
+
 from webviz_subsurface._utils.enum_shim import StrEnum
 
 
@@ -70,3 +72,9 @@ class LayoutStyle:
         "line-height": "30px",
         "background-color": "lightgrey",
     }
+
+
+class MenuOptions(TypedDict):
+    zones: List[str]
+    regions: List[str]
+    phases: List[str]

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
@@ -20,6 +20,7 @@ from webviz_subsurface.plugins._co2_leakage._utilities.containment_data_provider
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     GraphSource,
     MapAttribute,
+    MenuOptions,
 )
 from webviz_subsurface.plugins._co2_leakage._utilities.unsmry_data_provider import (
     UnsmryDataProvider
@@ -164,17 +165,14 @@ def init_menu_options(
     ensemble_roots: Dict[str, str],
     mass_table: Dict[str, ContainmentDataProvider],
     actual_volume_table: Dict[str, ContainmentDataProvider],
+    unsmry_providers: Dict[str, UnsmryDataProvider],
 ) -> Dict[str, Dict[str, Dict[str, List[str]]]]:
-    options: Dict[str, Dict[str, Dict[str, List[str]]]] = {}
+    options: Dict[str, Dict[str, MenuOptions]] = {}
     for ens in ensemble_roots.keys():
         options[ens] = {
-            GraphSource.CONTAINMENT_MASS: mass_table[ens].get_menu_options(),
-            GraphSource.CONTAINMENT_ACTUAL_VOLUME: actual_volume_table[ens].get_menu_options(),
-            GraphSource.UNSMRY: {
-                "zones": [],
-                "regions": [],
-                "phases": ["total", "gas", "aqueous"],
-            },
+            GraphSource.CONTAINMENT_MASS: mass_table[ens].menu_options,
+            GraphSource.CONTAINMENT_ACTUAL_VOLUME: actual_volume_table[ens].menu_options,
+            GraphSource.UNSMRY: unsmry_providers[ens].menu_options,
         }
     return options
 

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
@@ -14,10 +14,15 @@ from webviz_subsurface._providers import (
     EnsembleTableProviderFactory,
 )
 from webviz_subsurface._utils.webvizstore_functions import read_csv
-from webviz_subsurface.plugins._co2_leakage._utilities.containment_data_provider import ContainmentDataProvider
+from webviz_subsurface.plugins._co2_leakage._utilities.containment_data_provider import (
+    ContainmentDataProvider
+)
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     GraphSource,
     MapAttribute,
+)
+from webviz_subsurface.plugins._co2_leakage._utilities.unsmry_data_provider import (
+    UnsmryDataProvider
 )
 from webviz_subsurface.plugins._map_viewer_fmu._tmp_well_pick_provider import (
     WellPickProvider,
@@ -77,17 +82,20 @@ def init_well_pick_provider(
     return well_pick_provider
 
 
-def init_table_provider(
+def init_unsmry_data_providers(
     ensemble_roots: Dict[str, str],
     table_rel_path: str,
-) -> Dict[str, EnsembleTableProvider]:
+) -> Dict[str, UnsmryDataProvider]:
     factory = EnsembleTableProviderFactory.instance()
     providers = {
         ens: _init_ensemble_table_provider(factory, ens, ens_path, table_rel_path)
         for ens, ens_path in ensemble_roots.items()
     }
-    providers = {k: v for k, v in providers if v is not None}
-    return providers
+    return {
+        k: UnsmryDataProvider(v)
+        for k, v in providers.items()
+        if v is not None
+    }
 
 
 def init_containment_data_providers(

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
@@ -123,17 +123,6 @@ def _init_ensemble_table_provider(
     ens_path: str,
     table_rel_path: str,
 ) -> Optional[EnsembleTableProvider]:
-    if ens_path.endswith(".csv"):
-        max_size_mb = _find_max_file_size_mb(ens_path, table_rel_path)
-        if max_size_mb > WARNING_THRESHOLD_CSV_FILE_SIZE_MB:
-            text = (
-                "Some CSV-files are very large and might create problems when loading."
-            )
-            text += f"\n  ensembles: {ens}"
-            text += f"\n  CSV-files: {table_rel_path}"
-            text += f"\n  Max size : {max_size_mb:.2f} MB"
-            LOGGER.warning(text)
-
     try:
         return factory.create_from_per_realization_arrow_file(
             ens_path, table_rel_path

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
@@ -133,12 +133,12 @@ def _init_ensemble_table_provider(
             LOGGER.warning(text)
 
     try:
-        return factory.create_from_per_realization_csv_file(
+        return factory.create_from_per_realization_arrow_file(
             ens_path, table_rel_path
         )
     except (KeyError, ValueError) as exc:
         try:
-            return factory.create_from_per_realization_arrow_file(
+            return factory.create_from_per_realization_csv_file(
                 ens_path, table_rel_path
             )
         except (KeyError, ValueError) as exc2:

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
@@ -85,8 +85,10 @@ def init_well_pick_provider(
 
 def init_unsmry_data_providers(
     ensemble_roots: Dict[str, str],
-    table_rel_path: str,
+    table_rel_path: Optional[str],
 ) -> Dict[str, UnsmryDataProvider]:
+    if table_rel_path is None:
+        return {}
     factory = EnsembleTableProviderFactory.instance()
     providers = {
         ens: _init_ensemble_table_provider(factory, ens, ens_path, table_rel_path)
@@ -166,14 +168,15 @@ def init_menu_options(
     mass_table: Dict[str, ContainmentDataProvider],
     actual_volume_table: Dict[str, ContainmentDataProvider],
     unsmry_providers: Dict[str, UnsmryDataProvider],
-) -> Dict[str, Dict[str, Dict[str, List[str]]]]:
-    options: Dict[str, Dict[str, MenuOptions]] = {}
+) -> Dict[str, Dict[GraphSource, MenuOptions]]:
+    options: Dict[str, Dict[GraphSource, MenuOptions]] = {}
     for ens in ensemble_roots.keys():
         options[ens] = {
             GraphSource.CONTAINMENT_MASS: mass_table[ens].menu_options,
             GraphSource.CONTAINMENT_ACTUAL_VOLUME: actual_volume_table[ens].menu_options,
-            GraphSource.UNSMRY: unsmry_providers[ens].menu_options,
         }
+        if ens in unsmry_providers:
+            options[ens][GraphSource.UNSMRY] = unsmry_providers[ens].menu_options
     return options
 
 

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
@@ -140,18 +140,6 @@ def _init_ensemble_table_provider(
     return None
 
 
-def _find_max_file_size_mb(ens_path: str, table_rel_path: str) -> float:
-    glob_pattern = os.path.join(ens_path, table_rel_path)
-    paths = glob.glob(glob_pattern)
-    max_size = 0.0
-    for file in paths:
-        if os.path.exists(file):
-            file_stats = os.stat(file)
-            size_in_mb = file_stats.st_size / (1024 * 1024)
-            max_size = max(max_size, size_in_mb)
-    return max_size
-
-
 def init_menu_options(
     ensemble_roots: Dict[str, str],
     mass_table: Dict[str, ContainmentDataProvider],

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
@@ -106,13 +106,16 @@ def generate_summary_figure(
         "trapped_gas": "trapped",
     }
 
+    first_real = None
     for (real, phase), sub_df in df_containment.groupby(["REAL", "phase"]):
+        if first_real is None:
+            first_real = real
         fig.add_scatter(
             x=sub_df["date"],
             y=sub_df["amount"],
             name=f"Containment script ({phase})",
             legendgroup=_col_names[phase],
-            showlegend=bool(real == 0),
+            showlegend=bool(first_real == real),
             marker_color=_colors[_col_names[phase]],
             line_dash="dash",
         )

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
@@ -1,40 +1,36 @@
-import dataclasses
-from typing import Iterable, List, Union
+from typing import Union
 
 import numpy as np
-import pandas as pd
 import plotly.colors
 import plotly.graph_objects as go
 
-from webviz_subsurface._providers import EnsembleTableProvider
-from webviz_subsurface.plugins._co2_leakage._utilities.containment_data_provider import ContainmentDataProvider
+from webviz_subsurface.plugins._co2_leakage._utilities.containment_data_provider import (
+    ContainmentDataProvider
+)
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     Co2MassScale,
     Co2VolumeScale,
+)
+from webviz_subsurface.plugins._co2_leakage._utilities.unsmry_data_provider import (
+    UnsmryDataProvider
 )
 
 
 # pylint: disable=too-many-locals
 def generate_summary_figure(
-    table_provider_unsmry: EnsembleTableProvider,
+    unsmry_provider: UnsmryDataProvider,
     scale: Union[Co2MassScale, Co2VolumeScale],
-    table_provider_containment: ContainmentDataProvider,
+    containment_provider: ContainmentDataProvider,
 ) -> go.Figure:
-    columns_unsmry = _column_subset_unsmry(table_provider_unsmry)
-    df_unsmry = _read_dataframe(
-        table_provider_unsmry,  columns_unsmry, scale
-    )
-    df_containment = table_provider_containment.extract_condensed_dataframe(scale)
+    df_unsmry = unsmry_provider.extract(scale)
+    df_containment = containment_provider.extract_condensed_dataframe(scale)
 
+    # TODO: expose these directly from data providers?
     r_min = min(df_unsmry.REAL)
-    unsmry_last_total = df_unsmry[df_unsmry.REAL == r_min]["total"].iloc[-1]
-    unsmry_last_mobile = df_unsmry[df_unsmry.REAL == r_min][columns_unsmry.mobile].iloc[
-        -1
-    ]
-    unsmry_last_dissolved = df_unsmry[df_unsmry.REAL == r_min][
-        columns_unsmry.dissolved
-    ].iloc[-1]
-    # TODO: expose these directly from table_provider_containment?
+    unsmry_last_total = df_unsmry[df_unsmry.REAL == r_min][unsmry_provider.colname_total].iloc[-1]
+    unsmry_last_mobile = df_unsmry[df_unsmry.REAL == r_min][unsmry_provider.colname_mobile].iloc[-1]
+    unsmry_last_dissolved = df_unsmry[df_unsmry.REAL == r_min][unsmry_provider.colname_dissolved].iloc[-1]
+
     containment_reference = df_containment[df_containment.REAL == r_min]
     containment_last_total = containment_reference[containment_reference["phase"] == "total"]["amount"].iloc[-1]
     containment_last_mobile = containment_reference[containment_reference["phase"] == "free_gas"]["amount"].iloc[-1]
@@ -66,8 +62,8 @@ def generate_summary_figure(
     showlegend = True
     for _, sub_df in df_unsmry.groupby("realization"):
         fig.add_scatter(
-            x=sub_df[columns_unsmry.time],
-            y=sub_df["total"],
+            x=sub_df[unsmry_provider.colname_date],
+            y=sub_df[unsmry_provider.colname_total],
             name="UNSMRY",
             legendgroup="total",
             legendgrouptitle_text=f"Total ({last_total_err_percentage} %)",
@@ -75,27 +71,27 @@ def generate_summary_figure(
             marker_color=_colors["total"],
         )
         fig.add_scatter(
-            x=sub_df[columns_unsmry.time],
-            y=sub_df[columns_unsmry.mobile],
-            name=f"UNSMRY ({columns_unsmry.mobile})",
+            x=sub_df[unsmry_provider.colname_date],
+            y=sub_df[unsmry_provider.colname_mobile],
+            name=f"UNSMRY ({unsmry_provider.colname_mobile})",
             legendgroup="mobile",
             legendgrouptitle_text=f"Mobile ({last_mobile_err_percentage} %)",
             showlegend=showlegend,
             marker_color=_colors["mobile"],
         )
         fig.add_scatter(
-            x=sub_df[columns_unsmry.time],
-            y=sub_df[columns_unsmry.dissolved],
-            name=f"UNSMRY ({columns_unsmry.dissolved})",
+            x=sub_df[unsmry_provider.colname_date],
+            y=sub_df[unsmry_provider.colname_dissolved],
+            name=f"UNSMRY ({unsmry_provider.colname_dissolved})",
             legendgroup="dissolved",
             legendgrouptitle_text=f"Dissolved ({last_dissolved_err_percentage} %)",
             showlegend=showlegend,
             marker_color=_colors["dissolved"],
         )
         fig.add_scatter(
-            x=sub_df[columns_unsmry.time],
-            y=sub_df[columns_unsmry.trapped],
-            name=f"UNSMRY ({columns_unsmry.trapped})",
+            x=sub_df[unsmry_provider.colname_date],
+            y=sub_df[unsmry_provider.colname_trapped],
+            name=f"UNSMRY ({unsmry_provider.colname_trapped})",
             legendgroup="trapped",
             legendgrouptitle_text="Trapped",
             showlegend=showlegend,
@@ -129,62 +125,3 @@ def generate_summary_figure(
     fig.layout.margin.l = 10
     fig.layout.margin.r = 10
     return fig
-
-
-@dataclasses.dataclass
-class _ColumnNames:
-    time: str
-    dissolved: str
-    trapped: str
-    mobile: str
-
-    def values(self) -> Iterable[str]:
-        return dataclasses.asdict(self).values()
-
-
-@dataclasses.dataclass
-class _ColumnNamesContainment:
-    time: str
-    dissolved: str
-    mobile: str
-
-    def values(self) -> Iterable[str]:
-        return dataclasses.asdict(self).values()
-
-
-def _read_dataframe(
-    table_provider: EnsembleTableProvider,
-    columns: _ColumnNames,
-    co2_scale: Union[Co2MassScale, Co2VolumeScale],
-) -> pd.DataFrame:
-    full = pd.concat(
-        [
-            table_provider.get_column_data(list(columns.values()), [real]).assign(
-                realization=real
-            )
-            for real in table_provider.realizations()
-        ]
-    )
-    full["total"] = (
-        full[columns.dissolved] + full[columns.trapped] + full[columns.mobile]
-    )
-    for col in [columns.dissolved, columns.trapped, columns.mobile, "total"]:
-        if co2_scale == Co2MassScale.MTONS:
-            full[col] = full[col] / 1e9
-        elif co2_scale == Co2MassScale.NORMALIZE:
-            full[col] = full[col] / full["total"].max()
-    return full
-
-
-def _column_subset_unsmry(table_provider: EnsembleTableProvider) -> _ColumnNames:
-    existing = set(table_provider.column_names())
-    assert "DATE" in existing
-    # Try PFLOTRAN names
-    col_names = _ColumnNames("DATE", "FGMDS", "FGMTR", "FGMGP")
-    if set(col_names.values()).issubset(existing):
-        return col_names
-    # Try Eclipse names
-    col_names = _ColumnNames("DATE", "FWCD", "FGCDI", "FGCDM")
-    if set(col_names.values()).issubset(existing):
-        return col_names
-    raise KeyError(f"Could not find suitable data columns among: {', '.join(existing)}")

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/unsmry_data_provider.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/unsmry_data_provider.py
@@ -1,0 +1,79 @@
+from typing import Union, Tuple
+
+import pandas as pd
+
+from webviz_subsurface._providers import EnsembleTableProvider
+from webviz_subsurface.plugins._co2_leakage._utilities.generic import Co2MassScale, Co2VolumeScale
+
+
+class UnsmryDataProvider:
+    def __init__(self, provider: EnsembleTableProvider):
+        self._provider = provider
+        (
+            self._colname_date,
+            self._colname_dissolved,
+            self._colname_trapped,
+            self._colname_mobile,
+        ) = UnsmryDataProvider._column_subset_unsmry(provider)
+        self._colname_total = "TOTAL"
+
+    @property
+    def colname_date(self) -> str:
+        return self._colname_date
+
+    @property
+    def colname_dissolved(self):
+        return self._colname_dissolved
+
+    @property
+    def colname_trapped(self):
+        return self._colname_trapped
+
+    @property
+    def colname_mobile(self):
+        return self._colname_mobile
+
+    @property
+    def colname_total(self):
+        return self._colname_total
+
+    def extract(self, scale: Union[Co2MassScale, Co2VolumeScale]) -> pd.DataFrame:
+        columns = [
+            self._colname_date,
+            self._colname_dissolved,
+            self._colname_trapped,
+            self._colname_mobile,
+        ]
+        full = pd.concat(
+            [
+                self._provider.get_column_data(columns, [real]).assign(
+                    realization=real
+                )
+                for real in self._provider.realizations()
+            ]
+        )
+        full[self._colname_total] = (
+            full[self._colname_dissolved]
+            + full[self._colname_trapped]
+            + full[self.colname_mobile]
+        )
+        total_max = full[self._colname_total].max()
+        for col in columns[1:] + [self._colname_total]:
+            if scale == Co2MassScale.MTONS:
+                full[col] = full[col] / 1e9
+            elif scale == Co2MassScale.NORMALIZE:
+                full[col] = full[col] / total_max
+        return full
+
+    @staticmethod
+    def _column_subset_unsmry(provider: EnsembleTableProvider) -> Tuple[str, str, str, str]:
+        existing = set(provider.column_names())
+        # Try PFLOTRAN names
+        col_names = ("DATE", "FGMDS", "FGMTR", "FGMGP")
+        if set(col_names).issubset(existing):
+            return col_names
+        # Try Eclipse names
+        col_names = ("DATE", "FWCD", "FGCDI", "FGCDM")
+        if set(col_names).issubset(existing):
+            return col_names
+        raise KeyError(f"Could not find suitable data columns among: {', '.join(existing)}")


### PR DESCRIPTION
This solves the issue in ccs-scripts relating to UNSMRY visualization not working. (I don't have access to ccs-scripts yet, so issues from there cannot be directly referenced)

The essence of the problem was a not-up-to-date data extraction from the containment EnsembleTableProvider. This has been fixed in the first commit.

In addition:
- The EnsembleTableProviders for containment data and unsmry data has been wrapped in two new classes. This (hopefully) makes it easier to derive how and when these summary data are being used, and also allows us to validate the EnsembleTableProvider in an isolated function
- Summary files can now be provided as arrow as well. We first attempt to read the summary file as arrow. If this fails, we try csv.