### PR TITLE
Add visualization menu

### DIFF
--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -135,7 +135,7 @@ class CO2Leakage(WebvizPluginABC):
                 webviz_settings, ensembles, map_attribute_names
             )
             self._map_thresholds = MapThresholds(self._map_attribute_names)
-            self._threshold_ids = self._map_thresholds.get_keys()
+            self._threshold_ids = list(self._map_thresholds.standard_thresholds.keys())
             # Surfaces
             self._ensemble_surface_providers = init_surface_providers(
                 webviz_settings, ensembles
@@ -181,7 +181,7 @@ class CO2Leakage(WebvizPluginABC):
 
         self._summed_co2: Dict[str, Any] = {}
         self._visualization_info = {
-            "thresholds": self._map_thresholds.get_standard_thresholds(),
+            "thresholds": self._map_thresholds.standard_thresholds,
             "n_clicks": 0,
             "change": False,
             "unit": "kg",

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -471,8 +471,8 @@ def _parse_polygon_file(filename: str) -> Dict[str, Any]:
 
 
 def process_visualization_info(
-    n_clicks: int,
-    threshold: Optional[float],
+    attribute: str,
+    thresholds: dict,
     unit: str,
     stored_info: Dict[str, Any],
     cache: Cache,
@@ -480,17 +480,21 @@ def process_visualization_info(
     """
     Clear surface cache if the threshold for visualization or mass unit is changed
     """
+    stored_info["attribute"] = attribute
+    if MapType[MapAttribute(attribute).name].value in ["PLUME", "MIGRATION_TIME"]:
+        return stored_info
     stored_info["change"] = False
-    stored_info["n_clicks"] = n_clicks
     if unit != stored_info["unit"]:
         stored_info["unit"] = unit
         stored_info["change"] = True
-    if threshold is not None and threshold != stored_info["threshold"]:
-        stored_info["threshold"] = threshold
+    if (
+        thresholds is not None
+        and thresholds[attribute] != stored_info["thresholds"][attribute]
+    ):
+        stored_info["thresholds"][attribute] = thresholds[attribute]
         stored_info["change"] = True
     if stored_info["change"]:
         cache.clear()
-    # stored_info["n_clicks"] = n_clicks
     return stored_info
 
 

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -11,7 +11,6 @@ from flask_caching import Cache
 
 from webviz_subsurface._providers import (
     EnsembleSurfaceProvider,
-    EnsembleTableProvider,
     SimulatedSurfaceAddress,
     StatisticalSurfaceAddress,
     SurfaceAddress,
@@ -34,11 +33,13 @@ from webviz_subsurface.plugins._co2_leakage._utilities.containment_data_provider
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     Co2MassScale,
     Co2VolumeScale,
+    FilteredMapAttribute,
     GraphSource,
     LayoutLabels,
     MapAttribute,
     MapType,
     MapGroup,
+    MenuOptions,
 )
 from webviz_subsurface.plugins._co2_leakage._utilities.summary_graphs import (
     generate_summary_figure,
@@ -56,12 +57,15 @@ from webviz_subsurface.plugins._map_viewer_fmu._tmp_well_pick_provider import (
 
 
 def property_origin(
-    attribute: MapAttribute, map_attribute_names: Dict[MapAttribute, str]
+    attribute: MapAttribute, map_attribute_names: FilteredMapAttribute
 ) -> str:
     if MapType[MapAttribute(attribute).name].value == "PLUME":
-        return [map_attribute_names[attr] for attr in MapAttribute if
-                MapGroup[attr.name].value == MapGroup[MapAttribute(attribute).name].value and
-                MapType[attr.name] == "MAX"][0]
+        return [
+            map_attribute_names[attr]
+            for attr in MapAttribute
+            if MapGroup[attr.name].value == MapGroup[MapAttribute(attribute).name].value
+            and MapType[attr.name] == "MAX"
+        ][0]
     return map_attribute_names[attribute]
 
 
@@ -83,7 +87,7 @@ class SurfaceData:
         color_map_name: str,
         readable_name_: str,
         visualization_info: Dict[str, Any],
-        map_attribute_names: Dict[MapAttribute, str],
+        map_attribute_names: FilteredMapAttribute,
     ) -> Tuple[Any, Optional[Any]]:
         surf_meta, img_url, summed_mass = publish_and_get_surface_metadata(
             server,
@@ -121,7 +125,7 @@ def derive_surface_address(
     attribute: MapAttribute,
     date: Optional[str],
     realization: List[int],
-    map_attribute_names: Dict[MapAttribute, str],
+    map_attribute_names: FilteredMapAttribute,
     statistic: str,
     contour_data: Optional[Dict[str, Any]],
 ) -> Union[SurfaceAddress, TruncatedSurfaceAddress]:
@@ -506,7 +510,7 @@ def process_containment_info(
     color_choice: str,
     mark_choice: Optional[str],
     sorting: str,
-    menu_options: Dict[str, List[str]],
+    menu_options: MenuOptions,
 ) -> Dict[str, Union[str, None, List[str], int]]:
     if mark_choice is None:
         mark_choice = "phase"

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/containment_data_provider.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/containment_data_provider.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import List, Union
 
 import pandas as pd
 
@@ -25,7 +25,7 @@ class ContainmentDataProvider:
         return self._menu_options
 
     @property
-    def realizations(self):
+    def realizations(self) -> List[int]:
         return self._provider.realizations()
 
     def extract_dataframe(
@@ -89,7 +89,7 @@ class ContainmentDataProvider:
         }
 
     @staticmethod
-    def _validate(provider: EnsembleTableProvider):
+    def _validate(provider: EnsembleTableProvider) -> None:
         col_names = provider.column_names()
         required_columns = ["date", "amount", "phase", "containment", "zone", "region"]
         missing_columns = [col for col in required_columns if col not in col_names]

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -180,17 +180,11 @@ class MenuOptions(TypedDict):
 
 class MapThresholds:
     def __init__(self, mapping: FilteredMapAttribute):
-        self._standard_thresholds = {
+        self.standard_thresholds = {
             MapAttribute[key.name].value: 0.0
             for key in mapping.filtered_values.keys()
             if MapType[MapAttribute[key.name].name].value
             not in ["PLUME", "MIGRATION_TIME"]
         }
-        if MapAttribute.MAX_AMFG in self._standard_thresholds.keys():
-            self._standard_thresholds[MapAttribute.MAX_AMFG] = 0.0005
-
-    def get_standard_thresholds(self) -> Dict:
-        return self._standard_thresholds
-
-    def get_keys(self) -> List:
-        return list(self._standard_thresholds.keys())
+        if MapAttribute.MAX_AMFG in self.standard_thresholds.keys():
+            self.standard_thresholds[MapAttribute.MAX_AMFG] = 0.0005

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -1,4 +1,4 @@
-from typing import TypedDict, List
+from typing import Dict, List, TypedDict
 
 from webviz_subsurface._utils.enum_shim import StrEnum
 
@@ -133,6 +133,7 @@ class LayoutLabels(StrEnum):
     COMMON_SELECTIONS = "Options and global filters"
     FEEDBACK = "User feedback"
     VISUALIZATION_UPDATE = "Update threshold"
+    VISUALIZATION_THRESHOLDS = "Manage visualization filter"
 
 
 # pylint: disable=too-few-public-methods
@@ -162,8 +163,34 @@ class LayoutStyle:
         "background-color": "lightgrey",
     }
 
+    THRESHOLDS_BUTTON = {
+        "marginTop": "10px",
+        "width": "100%",
+        "height": "30px",
+        "line-height": "30px",
+        "padding": "0",
+        "background-color": "lightgrey",
+    }
+
 
 class MenuOptions(TypedDict):
     zones: List[str]
     regions: List[str]
     phases: List[str]
+
+
+class MapThresholds:
+    def __init__(self, mapping: FilteredMapAttribute):
+        self._standard_thresholds = {
+            MapAttribute[key.name].value: 0
+            for key in mapping.filtered_values.keys()
+            if MapType[MapAttribute[key.name].name].value not in ["PLUME", "MIGRATION_TIME"]
+        }
+        if MapAttribute.MAX_AMFG in self._standard_thresholds.keys():
+            self._standard_thresholds[MapAttribute.MAX_AMFG] = 0.0005
+
+    def get_standard_thresholds(self):
+        return self._standard_thresholds
+
+    def get_keys(self):
+        return list(self._standard_thresholds.keys())

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -65,7 +65,7 @@ class MapNamingConvention(StrEnum):
 
 
 class FilteredMapAttribute:
-    def __init__(self, mapping):
+    def __init__(self, mapping: Dict):
         self.mapping = mapping
         map_types = {
             key: MapType[key].value
@@ -86,21 +86,20 @@ class FilteredMapAttribute:
         self.mapping.update(plume_request)
         self.filtered_values = self.filter_map_attribute()
 
-    def filter_map_attribute(self):
+    def filter_map_attribute(self) -> Dict:
         return {
             MapAttribute[key]: self.mapping[MapAttribute[key].value]
             for key in MapAttribute.__members__
             if MapAttribute[key].value in self.mapping
         }
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: MapAttribute) -> MapAttribute:
         if isinstance(key, MapAttribute):
             return self.filtered_values[key]
-        else:
-            raise KeyError(f"Key must be a MapAttribute, " f"got {type(key)} instead.")
+        raise KeyError(f"Key must be a MapAttribute, " f"got {type(key)} instead.")
 
     @property
-    def values(self):
+    def values(self) -> Dict:
         return self.filtered_values
 
 
@@ -182,15 +181,16 @@ class MenuOptions(TypedDict):
 class MapThresholds:
     def __init__(self, mapping: FilteredMapAttribute):
         self._standard_thresholds = {
-            MapAttribute[key.name].value: 0
+            MapAttribute[key.name].value: 0.0
             for key in mapping.filtered_values.keys()
-            if MapType[MapAttribute[key.name].name].value not in ["PLUME", "MIGRATION_TIME"]
+            if MapType[MapAttribute[key.name].name].value
+            not in ["PLUME", "MIGRATION_TIME"]
         }
         if MapAttribute.MAX_AMFG in self._standard_thresholds.keys():
             self._standard_thresholds[MapAttribute.MAX_AMFG] = 0.0005
 
-    def get_standard_thresholds(self):
+    def get_standard_thresholds(self) -> Dict:
         return self._standard_thresholds
 
-    def get_keys(self):
+    def get_keys(self) -> List:
         return list(self._standard_thresholds.keys())

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
@@ -1,4 +1,3 @@
-import glob
 import logging
 import os
 import warnings
@@ -41,7 +40,7 @@ WARNING_THRESHOLD_CSV_FILE_SIZE_MB = 100.0
 def build_mapping(
     webviz_settings: WebvizSettings,
     ensembles: List[str],
-) -> Dict[MapAttribute, str]:
+) -> Dict[str, str]:
     available_attrs_per_ensemble = [
         discover_per_realization_surface_files(
             webviz_settings.shared_settings["scratch_ensembles"][ens],
@@ -55,9 +54,9 @@ def build_mapping(
     unique_attributes = set()
     for ens_attr in full_attr_list:
         unique_attributes.update(ens_attr)
-    unique_attributes = list(unique_attributes)
+    unique_attributes_list = list(unique_attributes)
     mapping = {}
-    for attr in unique_attributes:
+    for attr in unique_attributes_list:
         for name_convention in MapNamingConvention:
             if attr == name_convention.value:
                 attribute_key = MapAttribute[name_convention.name].name

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
@@ -71,9 +71,12 @@ def publish_and_get_surface_metadata(
             summed_mass = np.ma.sum(surface.values)
         if (
             MapType[address_map_attribute.name].value != "MIGRATION_TIME"
-            and visualization_info["threshold"] >= 0
+            and visualization_info["thresholds"][visualization_info["attribute"]] >= 0
         ):
-            surface.operation("elile", visualization_info["threshold"])
+            surface.operation(
+                "elile",
+                visualization_info["thresholds"][visualization_info["attribute"]],
+            )
         server.publish_surface(qualified_address, surface)
         surf_meta = server.get_surface_metadata(qualified_address)
     return surf_meta, server.encode_partial_url(qualified_address), summed_mass

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
@@ -18,7 +18,7 @@ from webviz_subsurface._providers.ensemble_surface_provider.ensemble_surface_pro
     SurfaceStatistic,
 )
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
-    MapAttribute,
+    FilteredMapAttribute,
     MapType,
 )
 from webviz_subsurface.plugins._co2_leakage._utilities.plume_extent import (
@@ -47,7 +47,7 @@ def publish_and_get_surface_metadata(
     provider: EnsembleSurfaceProvider,
     address: Union[SurfaceAddress, TruncatedSurfaceAddress],
     visualization_info: Dict[str, Any],
-    map_attribute_names: Dict[MapAttribute, str],
+    map_attribute_names: FilteredMapAttribute,
 ) -> Tuple[Optional[SurfaceImageMeta], Optional[str], Optional[Any]]:
     if isinstance(address, TruncatedSurfaceAddress):
         return _publish_and_get_truncated_surface_metadata(server, provider, address)
@@ -64,8 +64,15 @@ def publish_and_get_surface_metadata(
         if not surface:
             warnings.warn(f"Could not find surface file with properties: {address}")
             return None, None, None
-        address_map_attribute = next((key for key, value in map_attribute_names.filtered_values.items()
-                                      if value == address.attribute), None)
+        address_map_attribute = next(
+            (
+                key
+                for key, value in map_attribute_names.filtered_values.items()
+                if value == address.attribute
+            ),
+            None,
+        )
+        assert address_map_attribute is not None
         if MapType[address_map_attribute.name].value == "MASS":
             surface.values = surface.values / SCALE_DICT[visualization_info["unit"]]
             summed_mass = np.ma.sum(surface.values)

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/unsmry_data_provider.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/unsmry_data_provider.py
@@ -43,19 +43,19 @@ class UnsmryDataProvider:
         return self._colname_date
 
     @property
-    def colname_dissolved(self):
+    def colname_dissolved(self) -> str:
         return self._colname_dissolved
 
     @property
-    def colname_trapped(self):
+    def colname_trapped(self) -> str:
         return self._colname_trapped
 
     @property
-    def colname_mobile(self):
+    def colname_mobile(self) -> str:
         return self._colname_mobile
 
     @property
-    def colname_total(self):
+    def colname_total(self) -> str:
         return self._colname_total
 
     def extract(self, scale: Union[Co2MassScale, Co2VolumeScale]) -> pd.DataFrame:
@@ -100,7 +100,7 @@ class UnsmryDataProvider:
         )
 
     @staticmethod
-    def _validate(provider: EnsembleTableProvider):
+    def _validate(provider: EnsembleTableProvider) -> None:
         try:
             UnsmryDataProvider._column_subset_unsmry(provider)
         except KeyError as e:

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -95,7 +95,7 @@ class ViewSettings(SettingsGroupABC):
         self._ensemble_surface_providers = ensemble_surface_providers
         self._map_attribute_names = map_attribute_names
         self._thresholds = map_thresholds
-        self._threshold_ids = self._thresholds.get_keys()
+        self._threshold_ids = list(self._thresholds.standard_thresholds.keys())
         self._color_scale_names = color_scale_names
         self._initial_surface = initial_surface
         self._well_names_dict = well_names_dict
@@ -510,7 +510,7 @@ class VisualizationThresholdsLayout(wcc.Dialog):
         thresholds: MapThresholds,
         visualization_update_id: str,
     ) -> None:
-        standard_thresholds = thresholds.get_standard_thresholds()
+        standard_thresholds = thresholds.standard_thresholds
 
         fields = [
             html.Div(

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -78,12 +78,13 @@ class ViewSettings(SettingsGroupABC):
         FEEDBACK_BUTTON = "feedback-button"
         FEEDBACK = "feedback"
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         ensemble_paths: Dict[str, str],
         ensemble_surface_providers: Dict[str, EnsembleSurfaceProvider],
         initial_surface: Optional[str],
-        map_attribute_names: Dict[MapAttribute, str],
+        map_attribute_names: FilteredMapAttribute,
         map_thresholds: MapThresholds,
         color_scale_names: List[str],
         well_names_dict: Dict[str, List[str]],
@@ -210,7 +211,7 @@ class ViewSettings(SettingsGroupABC):
             if len(surfaces) == 0:
                 warning = f"Surface not found for property: {prop}.\n"
                 warning += f"Expected name: <formation>--{prop_name}"
-                if MapType[MapAttribute(attribute).name].value != "MIGRATION_TIME":
+                if MapType[MapAttribute(prop).name].value != "MIGRATION_TIME":
                     warning += "--<date>"
                 warnings.warn(warning + ".gri")
             # Formation names
@@ -589,7 +590,7 @@ class MapSelectorLayout(wcc.Selectors):
         cm_max_auto_id: str,
         mass_unit_id: str,
         mass_unit_update_id: str,
-        map_attribute_names: Dict[MapAttribute, str],
+        map_attribute_names: FilteredMapAttribute,
     ):
         default_colormap = (
             "turbo (Seq)"
@@ -688,6 +689,7 @@ class GraphSelectorsLayout(wcc.Selectors):
         "flexDirection": "row",
     }
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         graph_source_id: str,
@@ -962,7 +964,9 @@ class EnsembleSelectorLayout(wcc.Selectors):
         )
 
 
-def _create_left_side_menu(map_group, map_attribute_names):
+def _create_left_side_menu(
+    map_group: str, map_attribute_names: FilteredMapAttribute
+) -> List:
     title = {
         "label": html.Span([f"{map_group}:"], style={"text-decoration": "underline"}),
         "value": "",
@@ -976,10 +980,11 @@ def _create_left_side_menu(map_group, map_attribute_names):
     return [title] + map_attribute_list
 
 
-def _compile_property_options(map_attribute_names) -> List[Dict[str, Any]]:
+def _compile_property_options(
+    map_attribute_names: FilteredMapAttribute,
+) -> List[Dict[str, Any]]:
     requested_map_groups = [
-        MapGroup[key.name].value
-        for key in map_attribute_names.filtered_values.keys()
+        MapGroup[key.name].value for key in map_attribute_names.filtered_values.keys()
     ]
     unique_requested_map_groups = list(set(requested_map_groups))
     return [

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -15,13 +15,14 @@ from webviz_subsurface._providers.ensemble_surface_provider.ensemble_surface_pro
 from webviz_subsurface.plugins._co2_leakage._utilities.callbacks import property_origin
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     Co2MassScale,
+    FilteredMapAttribute,
     GraphSource,
     LayoutLabels,
     LayoutStyle,
     MapAttribute,
-    MapType,
     MapGroup,
-    FilteredMapAttribute,
+    MapThresholds,
+    MapType,
     MenuOptions,
 )
 
@@ -68,9 +69,11 @@ class ViewSettings(SettingsGroupABC):
         PLUME_THRESHOLD = "plume-threshold"
         PLUME_SMOOTHING = "plume-smoothing"
 
-        VISUALIZATION_THRESHOLD = "visualization-threshold"
         VISUALIZATION_UPDATE = "visualization-update"
+        VISUALIZATION_THRESHOLD_BUTTON = "visualization-threshold-button"
+        VISUALIZATION_THRESHOLD_DIALOG = "visualization-threshold-dialog"
         MASS_UNIT = "mass-unit"
+        MASS_UNIT_UPDATE = "mass-unit-update"
 
         FEEDBACK_BUTTON = "feedback-button"
         FEEDBACK = "feedback"
@@ -81,6 +84,7 @@ class ViewSettings(SettingsGroupABC):
         ensemble_surface_providers: Dict[str, EnsembleSurfaceProvider],
         initial_surface: Optional[str],
         map_attribute_names: Dict[MapAttribute, str],
+        map_thresholds: MapThresholds,
         color_scale_names: List[str],
         well_names_dict: Dict[str, List[str]],
         menu_options: Dict[str, Dict[GraphSource, MenuOptions]],
@@ -89,6 +93,8 @@ class ViewSettings(SettingsGroupABC):
         self._ensemble_paths = ensemble_paths
         self._ensemble_surface_providers = ensemble_surface_providers
         self._map_attribute_names = map_attribute_names
+        self._thresholds = map_thresholds
+        self._threshold_ids = self._thresholds.get_keys()
         self._color_scale_names = color_scale_names
         self._initial_surface = initial_surface
         self._well_names_dict = well_names_dict
@@ -115,6 +121,11 @@ class ViewSettings(SettingsGroupABC):
                 list(self._ensemble_paths.keys()),
             ),
             FilterSelectorLayout(self.register_component_unique_id(self.Ids.FORMATION)),
+            VisualizationThresholdsLayout(
+                self._threshold_ids,
+                self._thresholds,
+                self.register_component_unique_id(self.Ids.VISUALIZATION_UPDATE),
+            ),
             MapSelectorLayout(
                 self._color_scale_names,
                 self.register_component_unique_id(self.Ids.PROPERTY),
@@ -124,9 +135,8 @@ class ViewSettings(SettingsGroupABC):
                 self.register_component_unique_id(self.Ids.CM_MAX),
                 self.register_component_unique_id(self.Ids.CM_MIN_AUTO),
                 self.register_component_unique_id(self.Ids.CM_MAX_AUTO),
-                self.register_component_unique_id(self.Ids.VISUALIZATION_THRESHOLD),
-                self.register_component_unique_id(self.Ids.VISUALIZATION_UPDATE),
                 self.register_component_unique_id(self.Ids.MASS_UNIT),
+                self.register_component_unique_id(self.Ids.MASS_UNIT_UPDATE),
                 self._map_attribute_names,
             ),
             GraphSelectorsLayout(
@@ -245,14 +255,16 @@ class ViewSettings(SettingsGroupABC):
             return len(min_auto) == 1, len(max_auto) == 1
 
         @callback(
-            Output(
-                self.component_unique_id(self.Ids.VISUALIZATION_THRESHOLD).to_string(),
-                "disabled",
-            ),
-            Input(self.component_unique_id(self.Ids.PROPERTY).to_string(), "value"),
+            output=[Output(id, "disabled") for id in self._threshold_ids],
+            inputs={
+                "attribute": Input(
+                    self.component_unique_id(self.Ids.PROPERTY).to_string(),
+                    "value",
+                )
+            },
         )
-        def set_visualization_threshold(attribute: str) -> bool:
-            return MapType[MapAttribute(attribute).name].value == "MIGRATION_TIME"
+        def disable_irrelevant_thresholds(attribute: str) -> List[bool]:
+            return [id != attribute for id in self._threshold_ids]
 
         @callback(
             Output(
@@ -478,6 +490,86 @@ class FilterSelectorLayout(wcc.Selectors):
         )
 
 
+class OpenVisualizationThresholdsButton(html.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            LayoutLabels.VISUALIZATION_THRESHOLDS,
+            id=ViewSettings.Ids.VISUALIZATION_THRESHOLD_BUTTON,
+            style=LayoutStyle.THRESHOLDS_BUTTON,
+            n_clicks=0,
+        )
+
+
+class VisualizationThresholdsLayout(wcc.Dialog):
+    """Layout for the visualization thresholds dialog"""
+
+    def __init__(
+        self,
+        ids: List[str],
+        thresholds: MapThresholds,
+        visualization_update_id: str,
+    ) -> None:
+        standard_thresholds = thresholds.get_standard_thresholds()
+
+        fields = [
+            html.Div(
+                "Here you can select a filter for the visualization of the map, "
+                "hiding values smaller than the selected minimum cutoff. "
+                "After changing the threshold value, press 'Update' to have the map reappear. "
+                "A value of -1 can be used to visualize zeros."
+            ),
+            html.Div("", style={"height": "30px"}),
+            html.Div(
+                [
+                    html.Div("Property:", style={"width": "42%"}),
+                    html.Div("Standard cutoff:", style={"width": "32%"}),
+                    html.Div("Minimum cutoff:", style={"width": "25%"}),
+                ],
+                style={"display": "flex", "flex-direction": "row"},
+            ),
+        ]
+        fields += [
+            html.Div(
+                [
+                    html.Div(id, style={"width": "42%"}),
+                    html.Div(standard_thresholds[id], style={"width": "32%"}),
+                    dcc.Input(
+                        id=id,
+                        type="number",
+                        value=standard_thresholds[id],
+                        style={"width": "25%"},
+                    ),
+                ],
+                style={"display": "flex", "flex-direction": "row"},
+            )
+            for id in ids
+        ]
+        fields.append(html.Div(style={"height": "20px"}))
+        fields.append(
+            html.Div(
+                [
+                    html.Div(style={"width": "80%"}),
+                    html.Button(
+                        "Update",
+                        id=visualization_update_id,
+                        style=LayoutStyle.VISUALIZATION_BUTTON,
+                        n_clicks=0,
+                    ),
+                ],
+                style={"display": "flex", "flex-direction": "row"},
+            )
+        )
+        super().__init__(
+            title=LayoutLabels.VISUALIZATION_THRESHOLDS,
+            id=ViewSettings.Ids.VISUALIZATION_THRESHOLD_DIALOG,
+            draggable=True,
+            open=False,
+            children=html.Div(
+                fields, style={"flex-direction": "column", "width": "500px"}
+            ),
+        )
+
+
 class MapSelectorLayout(wcc.Selectors):
     _CM_RANGE = {
         "display": "flex",
@@ -495,9 +587,8 @@ class MapSelectorLayout(wcc.Selectors):
         cm_max_id: str,
         cm_min_auto_id: str,
         cm_max_auto_id: str,
-        visualization_threshold_id: str,
-        visualization_update_id: str,
         mass_unit_id: str,
+        mass_unit_update_id: str,
         map_attribute_names: Dict[MapAttribute, str],
     ):
         default_colormap = (
@@ -563,32 +654,28 @@ class MapSelectorLayout(wcc.Selectors):
                             ],
                             style=self._CM_RANGE,
                         ),
-                        "Visualization threshold",
+                        "Mass unit (for mass maps)",
                         html.Div(
                             [
-                                dcc.Input(
-                                    id=visualization_threshold_id,
-                                    type="number",
-                                    value=-1.0,
-                                    style={"width": "70%"},
+                                html.Div(
+                                    wcc.Dropdown(
+                                        id=mass_unit_id,
+                                        options=["kg", "tons", "M tons"],
+                                        value="kg",
+                                        clearable=False,
+                                    ),
+                                    style={"width": "50%"},
                                 ),
-                                html.Div(style={"width": "5%"}),
                                 html.Button(
-                                    "Update",
-                                    id=visualization_update_id,
+                                    "Update unit",
+                                    id=mass_unit_update_id,
                                     style=LayoutStyle.VISUALIZATION_BUTTON,
                                     n_clicks=0,
                                 ),
                             ],
                             style={"display": "flex"},
                         ),
-                        "Mass unit (for mass maps)",
-                        wcc.Dropdown(
-                            id=mass_unit_id,
-                            options=["kg", "tons", "M tons"],
-                            value="kg",
-                            clearable=False,
-                        ),
+                        OpenVisualizationThresholdsButton(),
                     ],
                 )
             ],


### PR DESCRIPTION
Moves the visualization filter functionality to a separate menu. This includes a proper explanation of the functionality, and provides the possibility of using separate filter thresholds for the different maps.

Also contains some general cleaning of formatting for the last few updates.