### PR TITLE
Enable usage without either maps or containment tables

### DIFF
--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -36,11 +36,13 @@ from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     MapType,
 )
 from webviz_subsurface.plugins._co2_leakage._utilities.initialization import (
-    init_containment_data_providers,
     init_containment_boundary_providers,
+    init_containment_data_providers,
+    init_dictionary_of_content,
     init_hazardous_boundary_providers,
     init_map_attribute_names,
     init_menu_options,
+    init_realizations,
     init_surface_providers,
     init_unsmry_data_providers,
     init_well_pick_provider,
@@ -119,6 +121,7 @@ class CO2Leakage(WebvizPluginABC):
                 ]
                 for ensemble_name in ensembles
             }
+            self._realizations_per_ensemble = init_realizations(ensemble_paths)
             self._surface_server = SurfaceImageServer.instance(app)
             self._polygons_server = FaultPolygonsServer.instance(app)
             self._map_attribute_names = init_map_attribute_names(
@@ -174,6 +177,10 @@ class CO2Leakage(WebvizPluginABC):
                 self._co2_actual_volume_table_providers,
                 self._unsmry_providers,
             )
+            self._content = init_dictionary_of_content(
+                self._menu_options,
+                len(self._map_attribute_names.mapping) > 0,
+            )
         except Exception as err:
             self._error_message = f"Plugin initialization failed: {err}"
             raise
@@ -197,6 +204,7 @@ class CO2Leakage(WebvizPluginABC):
         self.add_shared_settings_group(
             ViewSettings(
                 ensemble_paths,
+                self._realizations_per_ensemble,
                 self._ensemble_surface_providers,
                 initial_surface,
                 self._map_attribute_names,
@@ -204,10 +212,11 @@ class CO2Leakage(WebvizPluginABC):
                 [c["name"] for c in self._color_tables],  # type: ignore
                 self._well_pick_names,
                 self._menu_options,
+                self._content,
             ),
             self.Ids.MAIN_SETTINGS,
         )
-        self.add_view(MainView(self._color_tables), self.Ids.MAIN_VIEW)
+        self.add_view(MainView(self._color_tables, self._content), self.Ids.MAIN_VIEW)
 
     @property
     def layout(self) -> html.Div:
@@ -257,379 +266,408 @@ class CO2Leakage(WebvizPluginABC):
     def _set_callbacks(self) -> None:
         # Cannot avoid many arguments since all the parameters are needed
         # to determine what to plot
-        # pylint: disable=too-many-arguments
-        @callback(
-            Output(self._view_component(MapViewElement.Ids.BAR_PLOT), "figure"),
-            Output(self._view_component(MapViewElement.Ids.TIME_PLOT), "figure"),
-            Output(
-                self._view_component(MapViewElement.Ids.TIME_PLOT_ONE_REAL), "figure"
-            ),
-            Input(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
-            Input(self._settings_component(ViewSettings.Ids.GRAPH_SOURCE), "value"),
-            Input(self._settings_component(ViewSettings.Ids.CO2_SCALE), "value"),
-            Input(self._settings_component(ViewSettings.Ids.REALIZATION), "value"),
-            Input(self._settings_component(ViewSettings.Ids.Y_MIN_AUTO_GRAPH), "value"),
-            Input(self._settings_component(ViewSettings.Ids.Y_MIN_GRAPH), "value"),
-            Input(self._settings_component(ViewSettings.Ids.Y_MAX_AUTO_GRAPH), "value"),
-            Input(self._settings_component(ViewSettings.Ids.Y_MAX_GRAPH), "value"),
-            Input(self._settings_component(ViewSettings.Ids.ZONE), "value"),
-            Input(self._settings_component(ViewSettings.Ids.REGION), "value"),
-            Input(self._settings_component(ViewSettings.Ids.PHASE), "value"),
-            Input(self._settings_component(ViewSettings.Ids.CONTAINMENT), "value"),
-            Input(self._settings_component(ViewSettings.Ids.COLOR_BY), "value"),
-            Input(self._settings_component(ViewSettings.Ids.MARK_BY), "value"),
-            Input(self._settings_component(ViewSettings.Ids.SORT_PLOT), "value"),
-        )
-        @callback_typecheck
-        def update_graphs(
-            ensemble: str,
-            source: GraphSource,
-            co2_scale: Union[Co2MassScale, Co2VolumeScale],
-            realizations: List[int],
-            y_min_auto: List[str],
-            y_min_val: Optional[float],
-            y_max_auto: List[str],
-            y_max_val: Optional[float],
-            zone: Optional[str],
-            region: Optional[str],
-            phase: str,
-            containment: str,
-            color_choice: str,
-            mark_choice: Optional[str],
-            sorting: str,
-        ) -> Tuple[Dict, go.Figure, go.Figure, go.Figure]:
-            # pylint: disable=too-many-locals
-            figs = [no_update] * 3
-            cont_info = process_containment_info(
-                zone,
-                region,
-                phase,
-                containment,
-                color_choice,
-                mark_choice,
-                sorting,
-                self._menu_options[ensemble][source],
+        if self._content["any_table"]:
+            # pylint: disable=too-many-arguments
+            @callback(
+                Output(self._view_component(MapViewElement.Ids.BAR_PLOT), "figure"),
+                Output(self._view_component(MapViewElement.Ids.TIME_PLOT), "figure"),
+                Output(
+                    self._view_component(MapViewElement.Ids.TIME_PLOT_ONE_REAL),
+                    "figure",
+                ),
+                Input(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
+                Input(self._settings_component(ViewSettings.Ids.GRAPH_SOURCE), "value"),
+                Input(self._settings_component(ViewSettings.Ids.CO2_SCALE), "value"),
+                Input(self._settings_component(ViewSettings.Ids.REALIZATION), "value"),
+                Input(
+                    self._settings_component(ViewSettings.Ids.Y_MIN_AUTO_GRAPH), "value"
+                ),
+                Input(self._settings_component(ViewSettings.Ids.Y_MIN_GRAPH), "value"),
+                Input(
+                    self._settings_component(ViewSettings.Ids.Y_MAX_AUTO_GRAPH), "value"
+                ),
+                Input(self._settings_component(ViewSettings.Ids.Y_MAX_GRAPH), "value"),
+                Input(self._settings_component(ViewSettings.Ids.ZONE), "value"),
+                Input(self._settings_component(ViewSettings.Ids.REGION), "value"),
+                Input(self._settings_component(ViewSettings.Ids.PHASE), "value"),
+                Input(self._settings_component(ViewSettings.Ids.CONTAINMENT), "value"),
+                Input(self._settings_component(ViewSettings.Ids.COLOR_BY), "value"),
+                Input(self._settings_component(ViewSettings.Ids.MARK_BY), "value"),
+                Input(self._settings_component(ViewSettings.Ids.SORT_PLOT), "value"),
             )
-            if source in [
-                GraphSource.CONTAINMENT_MASS,
-                GraphSource.CONTAINMENT_ACTUAL_VOLUME,
-            ]:
-                y_limits = [
-                    y_min_val if len(y_min_auto) == 0 else None,
-                    y_max_val if len(y_max_auto) == 0 else None,
-                ]
-                if (
-                    source == GraphSource.CONTAINMENT_MASS
-                    and ensemble in self._co2_table_providers
-                ):
-                    figs[: len(figs)] = generate_containment_figures(
-                        self._co2_table_providers[ensemble],
-                        co2_scale,
-                        realizations[0],
-                        y_limits,
-                        cont_info,
-                    )
-                elif (
-                    source == GraphSource.CONTAINMENT_ACTUAL_VOLUME
-                    and ensemble in self._co2_actual_volume_table_providers
-                ):
-                    figs[: len(figs)] = generate_containment_figures(
-                        self._co2_actual_volume_table_providers[ensemble],
-                        co2_scale,
-                        realizations[0],
-                        y_limits,
-                        cont_info,
-                    )
-                set_plot_ids(figs, source, co2_scale, cont_info, realizations)
-            elif source == GraphSource.UNSMRY:
-                if self._unsmry_providers is not None:
-                    if ensemble in self._unsmry_providers:
-                        figs[0] = go.Figure()
-                        figs[1] = generate_unsmry_figures(
-                            self._unsmry_providers[ensemble],
-                            co2_scale,
+            @callback_typecheck
+            def update_graphs(
+                ensemble: str,
+                source: GraphSource,
+                co2_scale: Union[Co2MassScale, Co2VolumeScale],
+                realizations: List[int],
+                y_min_auto: List[str],
+                y_min_val: Optional[float],
+                y_max_auto: List[str],
+                y_max_val: Optional[float],
+                zone: Optional[str],
+                region: Optional[str],
+                phase: str,
+                containment: str,
+                color_choice: str,
+                mark_choice: Optional[str],
+                sorting: str,
+            ) -> Tuple[Dict, go.Figure, go.Figure, go.Figure]:
+                # pylint: disable=too-many-locals
+                figs = [no_update] * 3
+                cont_info = process_containment_info(
+                    zone,
+                    region,
+                    phase,
+                    containment,
+                    color_choice,
+                    mark_choice,
+                    sorting,
+                    self._menu_options[ensemble][source],
+                )
+                if source in [
+                    GraphSource.CONTAINMENT_MASS,
+                    GraphSource.CONTAINMENT_ACTUAL_VOLUME,
+                ]:
+                    y_limits = [
+                        y_min_val if len(y_min_auto) == 0 else None,
+                        y_max_val if len(y_max_auto) == 0 else None,
+                    ]
+                    if (
+                        source == GraphSource.CONTAINMENT_MASS
+                        and ensemble in self._co2_table_providers
+                    ):
+                        figs[: len(figs)] = generate_containment_figures(
                             self._co2_table_providers[ensemble],
+                            co2_scale,
+                            realizations[0],
+                            y_limits,
+                            cont_info,
                         )
-                        figs[2] = go.Figure()
-                else:
-                    LOGGER.warning(
-                        """UNSMRY file has not been specified as input.
-                         Please use unsmry_relpath in the configuration."""
-                    )
-            return figs  # type: ignore
+                    elif (
+                        source == GraphSource.CONTAINMENT_ACTUAL_VOLUME
+                        and ensemble in self._co2_actual_volume_table_providers
+                    ):
+                        figs[: len(figs)] = generate_containment_figures(
+                            self._co2_actual_volume_table_providers[ensemble],
+                            co2_scale,
+                            realizations[0],
+                            y_limits,
+                            cont_info,
+                        )
+                    set_plot_ids(figs, source, co2_scale, cont_info, realizations)
+                elif source == GraphSource.UNSMRY:
+                    if self._unsmry_providers is not None:
+                        if ensemble in self._unsmry_providers:
+                            figs[0] = go.Figure()
+                            figs[1] = generate_unsmry_figures(
+                                self._unsmry_providers[ensemble],
+                                co2_scale,
+                                self._co2_table_providers[ensemble],
+                            )
+                            figs[2] = go.Figure()
+                    else:
+                        LOGGER.warning(
+                            """UNSMRY file has not been specified as input.
+                             Please use unsmry_relpath in the configuration."""
+                        )
+                return figs  # type: ignore
 
-        @callback(
-            Output(self._view_component(MapViewElement.Ids.DATE_SLIDER), "marks"),
-            Output(self._view_component(MapViewElement.Ids.DATE_SLIDER), "value"),
-            Input(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
-        )
-        def set_dates(ensemble: str) -> Tuple[Dict[int, Dict[str, Any]], Optional[int]]:
-            if ensemble is None:
-                return {}, None
-            # Dates
-            date_list = self._ensemble_dates(ensemble)
-            dates = {
-                i: {
-                    "label": f"{d[:4]}",
-                    "style": {"writingMode": "vertical-rl"},
-                }
-                for i, d in enumerate(date_list)
-            }
-            if len(dates.keys()) > 0:
-                return dates, max(dates.keys())
-            return dates, None
-
-        @callback(
-            Output(self._view_component(MapViewElement.Ids.DATE_WRAPPER), "style"),
-            Input(self._settings_component(ViewSettings.Ids.PROPERTY), "value"),
-        )
-        def toggle_date_slider(attribute: str) -> Dict[str, str]:
-            if MapType[MapAttribute(attribute).name].value == "MIGRATION_TIME":
-                return {"display": "none"}
-            return {}
-
-        @callback(
-            Output(self._settings_component(ViewSettings.Ids.CO2_SCALE), "options"),
-            Output(self._settings_component(ViewSettings.Ids.CO2_SCALE), "value"),
-            Input(self._settings_component(ViewSettings.Ids.GRAPH_SOURCE), "value"),
-        )
-        def make_unit_list(
-            attribute: str,
-        ) -> Union[
-            Tuple[List[Any], Co2MassScale],
-            Tuple[List[Any], Co2VolumeScale],
-        ]:
-            if attribute == GraphSource.CONTAINMENT_ACTUAL_VOLUME:
-                return list(Co2VolumeScale), Co2VolumeScale.BILLION_CUBIC_METERS
-            return list(Co2MassScale), Co2MassScale.MTONS
-
-        @callback(
-            Output(ViewSettings.Ids.OPTIONS_DIALOG_WELL_FILTER, "options"),
-            Output(ViewSettings.Ids.OPTIONS_DIALOG_WELL_FILTER, "value"),
-            Output(ViewSettings.Ids.OPTIONS_DIALOG_WELL_FILTER, "style"),
-            Output(ViewSettings.Ids.WELL_FILTER_HEADER, "style"),
-            Input(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
-        )
-        def set_well_options(
-            ensemble: str,
-        ) -> Tuple[List[Any], List[str], Dict[Any, Any], Dict[Any, Any]]:
-            return (
-                [{"label": i, "value": i} for i in self._well_pick_names[ensemble]],
-                self._well_pick_names[ensemble],
-                {
-                    "display": "block" if self._well_pick_names[ensemble] else "none",
-                    "height": f"{len(self._well_pick_names[ensemble]) * 22}px",
-                },
-                {
-                    "flex": 3,
-                    "minWidth": "20px",
-                    "display": "block" if self._well_pick_names[ensemble] else "none",
-                },
+            @callback(
+                Output(self._settings_component(ViewSettings.Ids.CO2_SCALE), "options"),
+                Output(self._settings_component(ViewSettings.Ids.CO2_SCALE), "value"),
+                Input(self._settings_component(ViewSettings.Ids.GRAPH_SOURCE), "value"),
             )
+            def make_unit_list(
+                attribute: str,
+            ) -> Union[
+                Tuple[List[Any], Co2MassScale],
+                Tuple[List[Any], Co2VolumeScale],
+            ]:
+                if attribute == GraphSource.CONTAINMENT_ACTUAL_VOLUME:
+                    return list(Co2VolumeScale), Co2VolumeScale.BILLION_CUBIC_METERS
+                return list(Co2MassScale), Co2MassScale.MTONS
 
-        # Cannot avoid many arguments and/or locals since all layers of the DeckGL map
-        # need to be updated simultaneously
-        # pylint: disable=too-many-arguments,too-many-locals
-        @callback(
-            Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "layers"),
-            Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "children"),
-            Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "views"),
-            inputs={
-                "attribute": Input(
-                    self._settings_component(ViewSettings.Ids.PROPERTY), "value"
-                ),
-                "date": Input(
-                    self._view_component(MapViewElement.Ids.DATE_SLIDER), "value"
-                ),
-                "formation": Input(
-                    self._settings_component(ViewSettings.Ids.FORMATION), "value"
-                ),
-                "realization": Input(
-                    self._settings_component(ViewSettings.Ids.REALIZATION), "value"
-                ),
-                "statistic": Input(
-                    self._settings_component(ViewSettings.Ids.STATISTIC), "value"
-                ),
-                "color_map_name": Input(
-                    self._settings_component(ViewSettings.Ids.COLOR_SCALE), "value"
-                ),
-                "cm_min_auto": Input(
-                    self._settings_component(ViewSettings.Ids.CM_MIN_AUTO), "value"
-                ),
-                "cm_min_val": Input(
-                    self._settings_component(ViewSettings.Ids.CM_MIN), "value"
-                ),
-                "cm_max_auto": Input(
-                    self._settings_component(ViewSettings.Ids.CM_MAX_AUTO), "value"
-                ),
-                "cm_max_val": Input(
-                    self._settings_component(ViewSettings.Ids.CM_MAX), "value"
-                ),
-                "plume_threshold": Input(
-                    self._settings_component(ViewSettings.Ids.PLUME_THRESHOLD), "value"
-                ),
-                "plume_smoothing": Input(
-                    self._settings_component(ViewSettings.Ids.PLUME_SMOOTHING), "value"
-                ),
-                "visualization_update": Input(
-                    self._settings_component(ViewSettings.Ids.VISUALIZATION_UPDATE),
-                    "n_clicks",
-                ),
-                "mass_unit": Input(
-                    self._settings_component(ViewSettings.Ids.MASS_UNIT), "value"
-                ),
-                "mass_unit_update": Input(
-                    self._settings_component(ViewSettings.Ids.MASS_UNIT_UPDATE),
-                    "n_clicks",
-                ),
-                "options_dialog_options": Input(
-                    ViewSettings.Ids.OPTIONS_DIALOG_OPTIONS, "value"
-                ),
-                "selected_wells": Input(
-                    ViewSettings.Ids.OPTIONS_DIALOG_WELL_FILTER, "value"
-                ),
-                "ensemble": Input(
-                    self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"
-                ),
-                "current_views": State(
-                    self._view_component(MapViewElement.Ids.DECKGL_MAP), "views"
-                ),
-                "thresholds": [Input(id, "value") for id in self._threshold_ids],
-            },
-        )
-        def update_map_attribute(
-            attribute: MapAttribute,
-            date: int,
-            formation: str,
-            realization: List[int],
-            statistic: str,
-            color_map_name: str,
-            cm_min_auto: List[str],
-            cm_min_val: Optional[float],
-            cm_max_auto: List[str],
-            cm_max_val: Optional[float],
-            plume_threshold: Optional[float],
-            plume_smoothing: Optional[float],
-            visualization_update: int,
-            mass_unit: str,
-            mass_unit_update: int,
-            options_dialog_options: List[int],
-            selected_wells: List[str],
-            ensemble: str,
-            current_views: List[Any],
-            thresholds: List[float],
-        ) -> Tuple[List[Dict[Any, Any]], List[Any], Dict[Any, Any]]:
-            # Unable to clear cache (when needed) without the protected member
-            # pylint: disable=protected-access
-            current_thresholds = dict(zip(self._threshold_ids, thresholds))
-            assert visualization_update >= 0  # Need the input to trigger callback
-            assert mass_unit_update >= 0  # These are just to silence pylint
-            self._visualization_info = process_visualization_info(
-                attribute,
-                current_thresholds,
-                mass_unit,
-                self._visualization_info,
-                self._surface_server._image_cache,
+        if self._content["maps"]:
+
+            @callback(
+                Output(self._view_component(MapViewElement.Ids.DATE_SLIDER), "marks"),
+                Output(self._view_component(MapViewElement.Ids.DATE_SLIDER), "value"),
+                Input(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
             )
-            if self._visualization_info["change"]:
-                return [], no_update, no_update
-            attribute = MapAttribute(attribute)
-            if len(realization) == 0 or ensemble is None:
-                raise PreventUpdate
-            if isinstance(date, int):
-                datestr = self._ensemble_dates(ensemble)[date]
-            elif date is None:
-                datestr = None
-            # Contour data
-            contour_data = None
-            if MapType[MapAttribute(attribute).name].value == "PLUME":
-                contour_data = {
-                    "property": property_origin(attribute, self._map_attribute_names),
-                    "threshold": plume_threshold,
-                    "smoothing": plume_smoothing,
+            def set_dates(
+                ensemble: str,
+            ) -> Tuple[Dict[int, Dict[str, Any]], Optional[int]]:
+                if ensemble is None:
+                    return {}, None
+                # Dates
+                date_list = self._ensemble_dates(ensemble)
+                dates = {
+                    i: {
+                        "label": f"{d[:4]}",
+                        "style": {"writingMode": "vertical-rl"},
+                    }
+                    for i, d in enumerate(date_list)
                 }
-            # Surface
-            surf_data, summed_mass = None, None
-            if formation is not None and len(realization) > 0:
-                surf_data, summed_mass = SurfaceData.from_server(
-                    server=self._surface_server,
-                    provider=self._ensemble_surface_providers[ensemble],
-                    address=derive_surface_address(
-                        formation,
-                        attribute,
-                        datestr,
-                        realization,
-                        self._map_attribute_names,
-                        statistic,
-                        contour_data,
-                    ),
-                    color_map_range=(
-                        cm_min_val if len(cm_min_auto) == 0 else None,
-                        cm_max_val if len(cm_max_auto) == 0 else None,
-                    ),
-                    color_map_name=color_map_name,
-                    readable_name_=readable_name(attribute),
-                    visualization_info=self._visualization_info,
-                    map_attribute_names=self._map_attribute_names,
+                if len(dates.keys()) > 0:
+                    return dates, max(dates.keys())
+                return dates, None
+
+            @callback(
+                Output(self._view_component(MapViewElement.Ids.DATE_WRAPPER), "style"),
+                Input(self._settings_component(ViewSettings.Ids.PROPERTY), "value"),
+            )
+            def toggle_date_slider(attribute: str) -> Dict[str, str]:
+                if MapType[MapAttribute(attribute).name].value == "MIGRATION_TIME":
+                    return {"display": "none"}
+                return {}
+
+            @callback(
+                Output(ViewSettings.Ids.OPTIONS_DIALOG_WELL_FILTER, "options"),
+                Output(ViewSettings.Ids.OPTIONS_DIALOG_WELL_FILTER, "value"),
+                Output(ViewSettings.Ids.OPTIONS_DIALOG_WELL_FILTER, "style"),
+                Output(ViewSettings.Ids.WELL_FILTER_HEADER, "style"),
+                Input(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
+            )
+            def set_well_options(
+                ensemble: str,
+            ) -> Tuple[List[Any], List[str], Dict[Any, Any], Dict[Any, Any]]:
+                return (
+                    [{"label": i, "value": i} for i in self._well_pick_names[ensemble]],
+                    self._well_pick_names[ensemble],
+                    {
+                        "display": (
+                            "block" if self._well_pick_names[ensemble] else "none"
+                        ),
+                        "height": f"{len(self._well_pick_names[ensemble]) * 22}px",
+                    },
+                    {
+                        "flex": 3,
+                        "minWidth": "20px",
+                        "display": (
+                            "block" if self._well_pick_names[ensemble] else "none"
+                        ),
+                    },
                 )
-            assert isinstance(self._visualization_info["unit"], str)
-            surf_data, self._summed_co2 = process_summed_mass(
-                formation,
-                realization,
-                datestr,
-                attribute,
-                summed_mass,
-                surf_data,
-                self._summed_co2,
-                self._visualization_info["unit"],
+
+            # Cannot avoid many arguments and/or locals since all layers of the DeckGL map
+            # need to be updated simultaneously
+            # pylint: disable=too-many-arguments,too-many-locals
+            @callback(
+                Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "layers"),
+                Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "children"),
+                Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "views"),
+                inputs={
+                    "attribute": Input(
+                        self._settings_component(ViewSettings.Ids.PROPERTY), "value"
+                    ),
+                    "date": Input(
+                        self._view_component(MapViewElement.Ids.DATE_SLIDER), "value"
+                    ),
+                    "formation": Input(
+                        self._settings_component(ViewSettings.Ids.FORMATION), "value"
+                    ),
+                    "realization": Input(
+                        self._settings_component(ViewSettings.Ids.REALIZATION), "value"
+                    ),
+                    "statistic": Input(
+                        self._settings_component(ViewSettings.Ids.STATISTIC), "value"
+                    ),
+                    "color_map_name": Input(
+                        self._settings_component(ViewSettings.Ids.COLOR_SCALE), "value"
+                    ),
+                    "cm_min_auto": Input(
+                        self._settings_component(ViewSettings.Ids.CM_MIN_AUTO), "value"
+                    ),
+                    "cm_min_val": Input(
+                        self._settings_component(ViewSettings.Ids.CM_MIN), "value"
+                    ),
+                    "cm_max_auto": Input(
+                        self._settings_component(ViewSettings.Ids.CM_MAX_AUTO), "value"
+                    ),
+                    "cm_max_val": Input(
+                        self._settings_component(ViewSettings.Ids.CM_MAX), "value"
+                    ),
+                    "plume_threshold": Input(
+                        self._settings_component(ViewSettings.Ids.PLUME_THRESHOLD),
+                        "value",
+                    ),
+                    "plume_smoothing": Input(
+                        self._settings_component(ViewSettings.Ids.PLUME_SMOOTHING),
+                        "value",
+                    ),
+                    "visualization_update": Input(
+                        self._settings_component(ViewSettings.Ids.VISUALIZATION_UPDATE),
+                        "n_clicks",
+                    ),
+                    "mass_unit": Input(
+                        self._settings_component(ViewSettings.Ids.MASS_UNIT), "value"
+                    ),
+                    "mass_unit_update": Input(
+                        self._settings_component(ViewSettings.Ids.MASS_UNIT_UPDATE),
+                        "n_clicks",
+                    ),
+                    "options_dialog_options": Input(
+                        ViewSettings.Ids.OPTIONS_DIALOG_OPTIONS, "value"
+                    ),
+                    "selected_wells": Input(
+                        ViewSettings.Ids.OPTIONS_DIALOG_WELL_FILTER, "value"
+                    ),
+                    "ensemble": Input(
+                        self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"
+                    ),
+                    "current_views": State(
+                        self._view_component(MapViewElement.Ids.DECKGL_MAP), "views"
+                    ),
+                    "thresholds": [Input(id, "value") for id in self._threshold_ids],
+                },
             )
-            plume_polygon = None
-            if contour_data is not None:
-                plume_polygon = get_plume_polygon(
-                    self._ensemble_surface_providers[ensemble],
-                    realization,
+            def update_map_attribute(
+                attribute: MapAttribute,
+                date: int,
+                formation: str,
+                realization: List[int],
+                statistic: str,
+                color_map_name: str,
+                cm_min_auto: List[str],
+                cm_min_val: Optional[float],
+                cm_max_auto: List[str],
+                cm_max_val: Optional[float],
+                plume_threshold: Optional[float],
+                plume_smoothing: Optional[float],
+                visualization_update: int,
+                mass_unit: str,
+                mass_unit_update: int,
+                options_dialog_options: List[int],
+                selected_wells: List[str],
+                ensemble: str,
+                current_views: List[Any],
+                thresholds: List[float],
+            ) -> Tuple[List[Dict[Any, Any]], List[Any], Dict[Any, Any]]:
+                # Unable to clear cache (when needed) without the protected member
+                # pylint: disable=protected-access
+                current_thresholds = dict(zip(self._threshold_ids, thresholds))
+                assert visualization_update >= 0  # Need the input to trigger callback
+                assert mass_unit_update >= 0  # These are just to silence pylint
+                self._visualization_info = process_visualization_info(
+                    attribute,
+                    current_thresholds,
+                    mass_unit,
+                    self._visualization_info,
+                    self._surface_server._image_cache,
+                )
+                if self._visualization_info["change"]:
+                    return [], no_update, no_update
+                attribute = MapAttribute(attribute)
+                if len(realization) == 0 or ensemble is None:
+                    raise PreventUpdate
+                if isinstance(date, int):
+                    datestr = self._ensemble_dates(ensemble)[date]
+                elif date is None:
+                    datestr = None
+                # Contour data
+                contour_data = None
+                if MapType[MapAttribute(attribute).name].value == "PLUME":
+                    contour_data = {
+                        "property": property_origin(
+                            attribute, self._map_attribute_names
+                        ),
+                        "threshold": plume_threshold,
+                        "smoothing": plume_smoothing,
+                    }
+                # Surface
+                surf_data, summed_mass = None, None
+                if formation is not None and len(realization) > 0:
+                    surf_data, summed_mass = SurfaceData.from_server(
+                        server=self._surface_server,
+                        provider=self._ensemble_surface_providers[ensemble],
+                        address=derive_surface_address(
+                            formation,
+                            attribute,
+                            datestr,
+                            realization,
+                            self._map_attribute_names,
+                            statistic,
+                            contour_data,
+                        ),
+                        color_map_range=(
+                            cm_min_val if len(cm_min_auto) == 0 else None,
+                            cm_max_val if len(cm_max_auto) == 0 else None,
+                        ),
+                        color_map_name=color_map_name,
+                        readable_name_=readable_name(attribute),
+                        visualization_info=self._visualization_info,
+                        map_attribute_names=self._map_attribute_names,
+                    )
+                assert isinstance(self._visualization_info["unit"], str)
+                surf_data, self._summed_co2 = process_summed_mass(
                     formation,
+                    realization,
                     datestr,
-                    contour_data,
+                    attribute,
+                    summed_mass,
+                    surf_data,
+                    self._summed_co2,
+                    self._visualization_info["unit"],
                 )
-            # Create layers and view bounds
-            layers = create_map_layers(
-                realizations=realization,
-                formation=formation,
-                surface_data=surf_data,
-                fault_polygon_url=(
-                    self._fault_polygon_handlers[ensemble].extract_fault_polygon_url(
-                        formation,
+                plume_polygon = None
+                if contour_data is not None:
+                    plume_polygon = get_plume_polygon(
+                        self._ensemble_surface_providers[ensemble],
                         realization,
+                        formation,
+                        datestr,
+                        contour_data,
                     )
-                ),
-                containment_bounds_provider=self._containment_bounds_provider.get(
-                    ensemble, None
-                ),
-                haz_bounds_provider=self._haz_bounds_provider.get(ensemble, None),
-                well_pick_provider=self._well_pick_provider.get(ensemble, None),
-                plume_extent_data=plume_polygon,
-                options_dialog_options=options_dialog_options,
-                selected_wells=selected_wells,
-            )
-            annotations = create_map_annotations(
-                formation=formation,
-                surface_data=surf_data,
-                colortables=self._color_tables,
-                attribute=attribute,
-                unit=self._visualization_info["unit"],
-            )
-            viewports = no_update if current_views else create_map_viewports()
-            return layers, annotations, viewports
+                # Create layers and view bounds
+                layers = create_map_layers(
+                    realizations=realization,
+                    formation=formation,
+                    surface_data=surf_data,
+                    fault_polygon_url=(
+                        self._fault_polygon_handlers[
+                            ensemble
+                        ].extract_fault_polygon_url(
+                            formation,
+                            realization,
+                        )
+                    ),
+                    containment_bounds_provider=self._containment_bounds_provider.get(
+                        ensemble, None
+                    ),
+                    haz_bounds_provider=self._haz_bounds_provider.get(ensemble, None),
+                    well_pick_provider=self._well_pick_provider.get(ensemble, None),
+                    plume_extent_data=plume_polygon,
+                    options_dialog_options=options_dialog_options,
+                    selected_wells=selected_wells,
+                )
+                annotations = create_map_annotations(
+                    formation=formation,
+                    surface_data=surf_data,
+                    colortables=self._color_tables,
+                    attribute=attribute,
+                    unit=self._visualization_info["unit"],
+                )
+                viewports = no_update if current_views else create_map_viewports()
+                return layers, annotations, viewports
 
-        @callback(
-            Output(ViewSettings.Ids.OPTIONS_DIALOG, "open"),
-            Input(ViewSettings.Ids.OPTIONS_DIALOG_BUTTON, "n_clicks"),
-        )
-        def open_close_options_dialog(_n_clicks: Optional[int]) -> bool:
-            if _n_clicks is not None:
-                return _n_clicks > 0
-            raise PreventUpdate
+            @callback(
+                Output(ViewSettings.Ids.OPTIONS_DIALOG, "open"),
+                Input(ViewSettings.Ids.OPTIONS_DIALOG_BUTTON, "n_clicks"),
+            )
+            def open_close_options_dialog(_n_clicks: Optional[int]) -> bool:
+                if _n_clicks is not None:
+                    return _n_clicks > 0
+                raise PreventUpdate
+
+            @callback(
+                Output(ViewSettings.Ids.VISUALIZATION_THRESHOLD_DIALOG, "open"),
+                Input(ViewSettings.Ids.VISUALIZATION_THRESHOLD_BUTTON, "n_clicks"),
+            )
+            def open_close_thresholds(_n_clicks: Optional[int]) -> bool:
+                if _n_clicks is not None:
+                    return _n_clicks > 0
+                raise PreventUpdate
 
         @callback(
             Output(ViewSettings.Ids.FEEDBACK, "open"),
@@ -640,51 +678,46 @@ class CO2Leakage(WebvizPluginABC):
                 return _n_clicks > 0
             raise PreventUpdate
 
-        @callback(
-            Output(ViewSettings.Ids.VISUALIZATION_THRESHOLD_DIALOG, "open"),
-            Input(ViewSettings.Ids.VISUALIZATION_THRESHOLD_BUTTON, "n_clicks"),
-        )
-        def open_close_thresholds(_n_clicks: Optional[int]) -> bool:
-            if _n_clicks is not None:
-                return _n_clicks > 0
-            raise PreventUpdate
+        if self._content["maps"] and self._content["any_table"]:
 
-        @callback(
-            Output(self._view_component(MapViewElement.Ids.TOP_ELEMENT), "style"),
-            Output(self._view_component(MapViewElement.Ids.BOTTOM_ELEMENT), "style"),
-            Output(self._view_component(MapViewElement.Ids.BAR_PLOT), "style"),
-            Output(self._view_component(MapViewElement.Ids.TIME_PLOT), "style"),
-            Output(
-                self._view_component(MapViewElement.Ids.TIME_PLOT_ONE_REAL), "style"
-            ),
-            Input(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
-            Input(self._view_component(MapViewElement.Ids.SIZE_SLIDER), "value"),
-            State(self._view_component(MapViewElement.Ids.TOP_ELEMENT), "style"),
-            State(self._view_component(MapViewElement.Ids.BOTTOM_ELEMENT), "style"),
-            Input(self._settings_component(ViewSettings.Ids.GRAPH_SOURCE), "value"),
-        )
-        def resize_plots(
-            ensemble: str,
-            slider_value: float,
-            top_style: Dict,
-            bottom_style: Dict,
-            source: GraphSource,
-        ) -> List[Dict]:
-            bottom_style["height"] = f"{slider_value}vh"
-            top_style["height"] = f"{80 - slider_value}vh"
+            @callback(
+                Output(self._view_component(MapViewElement.Ids.TOP_ELEMENT), "style"),
+                Output(
+                    self._view_component(MapViewElement.Ids.BOTTOM_ELEMENT), "style"
+                ),
+                Output(self._view_component(MapViewElement.Ids.BAR_PLOT), "style"),
+                Output(self._view_component(MapViewElement.Ids.TIME_PLOT), "style"),
+                Output(
+                    self._view_component(MapViewElement.Ids.TIME_PLOT_ONE_REAL), "style"
+                ),
+                Input(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
+                Input(self._view_component(MapViewElement.Ids.SIZE_SLIDER), "value"),
+                State(self._view_component(MapViewElement.Ids.TOP_ELEMENT), "style"),
+                State(self._view_component(MapViewElement.Ids.BOTTOM_ELEMENT), "style"),
+                Input(self._settings_component(ViewSettings.Ids.GRAPH_SOURCE), "value"),
+            )
+            def resize_plots(
+                ensemble: str,
+                slider_value: float,
+                top_style: Dict,
+                bottom_style: Dict,
+                source: GraphSource,
+            ) -> List[Dict]:
+                bottom_style["height"] = f"{slider_value}vh"
+                top_style["height"] = f"{80 - slider_value}vh"
 
-            styles = [{"height": f"{slider_value * 0.9 - 4}vh", "width": "90%"}] * 3
-            if source == GraphSource.UNSMRY and self._unsmry_providers is None:
-                styles = [{"display": "none"}] * 3
-            elif (
-                source == GraphSource.CONTAINMENT_MASS
-                and ensemble not in self._co2_table_providers
-            ):
-                styles = [{"display": "none"}] * 3
-            elif (
-                source == GraphSource.CONTAINMENT_ACTUAL_VOLUME
-                and ensemble not in self._co2_actual_volume_table_providers
-            ):
-                styles = [{"display": "none"}] * 3
+                styles = [{"height": f"{slider_value * 0.9 - 4}vh", "width": "90%"}] * 3
+                if source == GraphSource.UNSMRY and self._unsmry_providers is None:
+                    styles = [{"display": "none"}] * 3
+                elif (
+                    source == GraphSource.CONTAINMENT_MASS
+                    and ensemble not in self._co2_table_providers
+                ):
+                    styles = [{"display": "none"}] * 3
+                elif (
+                    source == GraphSource.CONTAINMENT_ACTUAL_VOLUME
+                    and ensemble not in self._co2_actual_volume_table_providers
+                ):
+                    styles = [{"display": "none"}] * 3
 
-            return [top_style, bottom_style] + styles
+                return [top_style, bottom_style] + styles

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -42,8 +42,8 @@ from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     GraphSource,
     LayoutLabels,
     MapAttribute,
-    MapType,
     MapGroup,
+    MapType,
     MenuOptions,
 )
 from webviz_subsurface.plugins._co2_leakage._utilities.summary_graphs import (

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/initialization.py
@@ -4,6 +4,7 @@ import warnings
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from fmu.ensemble import ScratchEnsemble
 from webviz_config import WebvizSettings
 
 from webviz_subsurface._providers import (
@@ -11,6 +12,9 @@ from webviz_subsurface._providers import (
     EnsembleSurfaceProviderFactory,
     EnsembleTableProvider,
     EnsembleTableProviderFactory,
+)
+from webviz_subsurface._providers.ensemble_surface_provider._surface_discovery import (
+    discover_per_realization_surface_files,
 )
 from webviz_subsurface.plugins._co2_leakage._utilities.containment_data_provider import (
     ContainmentDataProvider,
@@ -22,21 +26,21 @@ from webviz_subsurface.plugins._co2_leakage._utilities.ensemble_well_picks impor
     EnsembleWellPicks,
 )
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
+    FilteredMapAttribute,
     GraphSource,
     MapAttribute,
     MapNamingConvention,
-    FilteredMapAttribute,
     MenuOptions,
 )
 from webviz_subsurface.plugins._co2_leakage._utilities.unsmry_data_provider import (
     UnsmryDataProvider,
 )
-from webviz_subsurface._providers.ensemble_surface_provider._surface_discovery import (
-    discover_per_realization_surface_files,
-)
-
 
 LOGGER = logging.getLogger(__name__)
+LOGGER_TO_SUPPRESS = logging.getLogger(
+    "webviz_subsurface._providers.ensemble_summary_provider._arrow_unsmry_import"
+)
+LOGGER_TO_SUPPRESS.setLevel(logging.ERROR)  # We replace the given warning with our own
 WARNING_THRESHOLD_CSV_FILE_SIZE_MB = 100.0
 
 
@@ -220,10 +224,20 @@ def _init_ensemble_table_provider(
             )
         except (KeyError, ValueError) as exc2:
             LOGGER.warning(
-                f'Tried reading "{table_rel_path}" for ensemble "{ens}" as csv with'
-                f" error {exc}, and as arrow with error {exc2}"
+                f'\nTried reading "{table_rel_path}" for ensemble "{ens}" as csv with'
+                f" error \n- {exc2}, \nand as arrow with error \n- {exc}"
             )
     return None
+
+
+def init_realizations(ensemble_paths: Dict[str, str]) -> Dict[str, List[int]]:
+    realization_per_ens = {}
+    for ens, ens_path in ensemble_paths.items():
+        scratch_ensemble = ScratchEnsemble("dummyEnsembleName", paths=ens_path).filter(
+            "OK"
+        )
+        realization_per_ens[ens] = sorted(list(scratch_ensemble.realizations.keys()))
+    return realization_per_ens
 
 
 def init_menu_options(
@@ -234,15 +248,44 @@ def init_menu_options(
 ) -> Dict[str, Dict[GraphSource, MenuOptions]]:
     options: Dict[str, Dict[GraphSource, MenuOptions]] = {}
     for ens in ensemble_roots.keys():
-        options[ens] = {
-            GraphSource.CONTAINMENT_MASS: mass_table[ens].menu_options,
-            GraphSource.CONTAINMENT_ACTUAL_VOLUME: actual_volume_table[
+        options[ens] = {}
+        if ens in mass_table:
+            options[ens][GraphSource.CONTAINMENT_MASS] = mass_table[ens].menu_options
+        if ens in actual_volume_table:
+            options[ens][GraphSource.CONTAINMENT_ACTUAL_VOLUME] = actual_volume_table[
                 ens
-            ].menu_options,
-        }
+            ].menu_options
         if ens in unsmry_providers:
             options[ens][GraphSource.UNSMRY] = unsmry_providers[ens].menu_options
     return options
+
+
+def init_dictionary_of_content(
+    menu_options: Dict[str, Dict[GraphSource, MenuOptions]],
+    has_maps: bool,
+) -> Dict[str, bool]:
+    options = next(iter(menu_options.values()))
+    content = {
+        "mass": GraphSource.CONTAINMENT_MASS in options,
+        "volume": GraphSource.CONTAINMENT_ACTUAL_VOLUME in options,
+        "unsmry": GraphSource.UNSMRY in options,
+    }
+    content["any_table"] = max(content.values())
+    content["maps"] = has_maps
+    content["zones"] = False
+    content["regions"] = False
+    if content["mass"] or content["volume"]:
+        content["zones"] = max(
+            len(inner_dict["zones"]) > 0
+            for outer_dict in menu_options.values()
+            for inner_dict in outer_dict.values()
+        )
+        content["regions"] = max(
+            len(inner_dict["regions"]) > 0
+            for outer_dict in menu_options.values()
+            for inner_dict in outer_dict.values()
+        )
+    return content
 
 
 def _process_file(file: Optional[str], ensemble_path: str) -> Optional[str]:

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/unsmry_data_provider.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/unsmry_data_provider.py
@@ -1,4 +1,4 @@
-from typing import Union, Tuple
+from typing import Tuple, Union
 
 import pandas as pd
 
@@ -8,7 +8,6 @@ from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     Co2VolumeScale,
     MenuOptions,
 )
-
 
 _PFLOTRAN_COLNAMES = ("DATE", "FGMDS", "FGMTR", "FGMGP")
 _ECLIPSE_COLNAMES = ("DATE", "FWCD", "FGCDI", "FGCDM")

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
@@ -13,9 +13,9 @@ class MainView(ViewABC):
     class Ids(StrEnum):
         MAIN_ELEMENT = "main-element"
 
-    def __init__(self, color_scales: List[Dict[str, Any]]):
+    def __init__(self, color_scales: List[Dict[str, Any]], content: Dict[str, bool]):
         super().__init__("Main View")
-        self._view_element = MapViewElement(color_scales)
+        self._view_element = MapViewElement(color_scales, content)
         self.add_view_element(self._view_element, self.Ids.MAIN_ELEMENT)
 
 
@@ -33,13 +33,17 @@ class MapViewElement(ViewElementABC):
         TOP_ELEMENT = "top-element"
         BOTTOM_ELEMENT = "bottom-element"
 
-    def __init__(self, color_scales: List[Dict[str, Any]]) -> None:
+    def __init__(
+        self, color_scales: List[Dict[str, Any]], content: Dict[str, bool]
+    ) -> None:
         super().__init__()
         self._color_scales = color_scales
+        self._content = content
 
     def inner_layout(self) -> Component:
-        return html.Div(
-            [
+        layout_elements = []
+        if self._content["maps"]:
+            layout_elements.append(
                 wcc.Frame(
                     # id=self.register_component_unique_id(LayoutElements.MAP_VIEW),
                     id=self.register_component_unique_id(self.Ids.TOP_ELEMENT),
@@ -78,14 +82,17 @@ class MapViewElement(ViewElementABC):
                         ),
                     ],
                     style={
-                        "height": "43vh",
+                        "height": "43vh" if self._content["any_table"] else "100%",
                     },
-                ),
+                )
+            )
+        if self._content["any_table"]:
+            layout_elements.append(
                 wcc.Frame(
                     # id=get_uuid(LayoutElements.PLOT_VIEW),
                     id=self.register_component_unique_id(self.Ids.BOTTOM_ELEMENT),
                     style={
-                        "height": "37vh",
+                        "height": "37vh" if self._content["maps"] else "100%",
                     },
                     children=[
                         html.Div(
@@ -98,7 +105,10 @@ class MapViewElement(ViewElementABC):
                             )
                         ),
                     ],
-                ),
+                )
+            )
+        if self._content["maps"] and self._content["any_table"]:
+            layout_elements.append(
                 html.Div(
                     [
                         wcc.Slider(
@@ -118,8 +128,10 @@ class MapViewElement(ViewElementABC):
                     style={
                         "width": "100%",
                     },
-                ),
-            ],
+                )
+            )
+        return html.Div(
+            layout_elements,
             style={
                 "display": "flex",
                 "flexDirection": "column",

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -15,6 +15,7 @@ from webviz_subsurface._providers.ensemble_surface_provider.ensemble_surface_pro
 from webviz_subsurface.plugins._co2_leakage._utilities.callbacks import property_origin
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     Co2MassScale,
+    Co2VolumeScale,
     FilteredMapAttribute,
     GraphSource,
     LayoutLabels,
@@ -82,6 +83,7 @@ class ViewSettings(SettingsGroupABC):
     def __init__(
         self,
         ensemble_paths: Dict[str, str],
+        realizations_per_ensemble: Dict[str, List[int]],
         ensemble_surface_providers: Dict[str, EnsembleSurfaceProvider],
         initial_surface: Optional[str],
         map_attribute_names: FilteredMapAttribute,
@@ -89,9 +91,11 @@ class ViewSettings(SettingsGroupABC):
         color_scale_names: List[str],
         well_names_dict: Dict[str, List[str]],
         menu_options: Dict[str, Dict[GraphSource, MenuOptions]],
+        content: Dict[str, bool],
     ):
         super().__init__("Settings")
         self._ensemble_paths = ensemble_paths
+        self._realizations_per_ensemble = realizations_per_ensemble
         self._ensemble_surface_providers = ensemble_surface_providers
         self._map_attribute_names = map_attribute_names
         self._thresholds = map_thresholds
@@ -100,82 +104,88 @@ class ViewSettings(SettingsGroupABC):
         self._initial_surface = initial_surface
         self._well_names_dict = well_names_dict
         self._menu_options = menu_options
-        self._has_zones = max(
-            len(inner_dict["zones"]) > 0
-            for outer_dict in menu_options.values()
-            for inner_dict in outer_dict.values()
-        )
-        self._has_regions = max(
-            len(inner_dict["regions"]) > 0
-            for outer_dict in menu_options.values()
-            for inner_dict in outer_dict.values()
-        )
-        self._has_unsmry = GraphSource.UNSMRY in next(iter(self._menu_options.values()))
+        self._content = content
 
     def layout(self) -> List[Component]:
-        return [
-            DialogLayout(self._well_names_dict, list(self._ensemble_paths.keys())),
-            OpenDialogButton(),
+        menu_layout = []
+        if self._content["maps"]:
+            menu_layout += [
+                DialogLayout(self._well_names_dict, list(self._ensemble_paths.keys())),
+                OpenDialogButton(),
+            ]
+        menu_layout.append(
             EnsembleSelectorLayout(
                 self.register_component_unique_id(self.Ids.ENSEMBLE),
                 self.register_component_unique_id(self.Ids.REALIZATION),
                 list(self._ensemble_paths.keys()),
-            ),
-            FilterSelectorLayout(self.register_component_unique_id(self.Ids.FORMATION)),
-            VisualizationThresholdsLayout(
-                self._threshold_ids,
-                self._thresholds,
-                self.register_component_unique_id(self.Ids.VISUALIZATION_UPDATE),
-            ),
-            MapSelectorLayout(
-                self._color_scale_names,
-                self.register_component_unique_id(self.Ids.PROPERTY),
-                self.register_component_unique_id(self.Ids.STATISTIC),
-                self.register_component_unique_id(self.Ids.COLOR_SCALE),
-                self.register_component_unique_id(self.Ids.CM_MIN),
-                self.register_component_unique_id(self.Ids.CM_MAX),
-                self.register_component_unique_id(self.Ids.CM_MIN_AUTO),
-                self.register_component_unique_id(self.Ids.CM_MAX_AUTO),
-                self.register_component_unique_id(self.Ids.MASS_UNIT),
-                self.register_component_unique_id(self.Ids.MASS_UNIT_UPDATE),
-                self._map_attribute_names,
-            ),
-            GraphSelectorsLayout(
-                self.register_component_unique_id(self.Ids.GRAPH_SOURCE),
-                self.register_component_unique_id(self.Ids.CO2_SCALE),
-                [
-                    self.register_component_unique_id(self.Ids.Y_MIN_GRAPH),
-                    self.register_component_unique_id(self.Ids.Y_MIN_AUTO_GRAPH),
-                ],
-                [
-                    self.register_component_unique_id(self.Ids.Y_MAX_GRAPH),
-                    self.register_component_unique_id(self.Ids.Y_MAX_AUTO_GRAPH),
-                ],
-                [
-                    self.register_component_unique_id(self.Ids.COLOR_BY),
-                    self.register_component_unique_id(self.Ids.MARK_BY),
-                    self.register_component_unique_id(self.Ids.SORT_PLOT),
-                    self.register_component_unique_id(self.Ids.ZONE),
-                    self.register_component_unique_id(self.Ids.ZONE_COL),
-                    self.register_component_unique_id(self.Ids.REGION),
-                    self.register_component_unique_id(self.Ids.REGION_COL),
-                    self.register_component_unique_id(self.Ids.ZONE_REGION),
-                    self.register_component_unique_id(self.Ids.PHASE),
-                    self.register_component_unique_id(self.Ids.PHASE_MENU),
-                    self.register_component_unique_id(self.Ids.CONTAINMENT),
-                    self.register_component_unique_id(self.Ids.CONTAINMENT_MENU),
-                ],
-                self._has_zones,
-                self._has_regions,
-                self._has_unsmry,
-            ),
-            ExperimentalFeaturesLayout(
-                self.register_component_unique_id(self.Ids.PLUME_THRESHOLD),
-                self.register_component_unique_id(self.Ids.PLUME_SMOOTHING),
-            ),
+            )
+        )
+        if self._content["maps"]:
+            menu_layout += [
+                FilterSelectorLayout(
+                    self.register_component_unique_id(self.Ids.FORMATION)
+                ),
+                VisualizationThresholdsLayout(
+                    self._threshold_ids,
+                    self._thresholds,
+                    self.register_component_unique_id(self.Ids.VISUALIZATION_UPDATE),
+                ),
+                MapSelectorLayout(
+                    self._color_scale_names,
+                    self.register_component_unique_id(self.Ids.PROPERTY),
+                    self.register_component_unique_id(self.Ids.STATISTIC),
+                    self.register_component_unique_id(self.Ids.COLOR_SCALE),
+                    self.register_component_unique_id(self.Ids.CM_MIN),
+                    self.register_component_unique_id(self.Ids.CM_MAX),
+                    self.register_component_unique_id(self.Ids.CM_MIN_AUTO),
+                    self.register_component_unique_id(self.Ids.CM_MAX_AUTO),
+                    self.register_component_unique_id(self.Ids.MASS_UNIT),
+                    self.register_component_unique_id(self.Ids.MASS_UNIT_UPDATE),
+                    self._map_attribute_names,
+                ),
+            ]
+        if self._content["any_table"]:
+            menu_layout.append(
+                GraphSelectorsLayout(
+                    self.register_component_unique_id(self.Ids.GRAPH_SOURCE),
+                    self.register_component_unique_id(self.Ids.CO2_SCALE),
+                    [
+                        self.register_component_unique_id(self.Ids.Y_MIN_GRAPH),
+                        self.register_component_unique_id(self.Ids.Y_MIN_AUTO_GRAPH),
+                    ],
+                    [
+                        self.register_component_unique_id(self.Ids.Y_MAX_GRAPH),
+                        self.register_component_unique_id(self.Ids.Y_MAX_AUTO_GRAPH),
+                    ],
+                    [
+                        self.register_component_unique_id(self.Ids.COLOR_BY),
+                        self.register_component_unique_id(self.Ids.MARK_BY),
+                        self.register_component_unique_id(self.Ids.SORT_PLOT),
+                        self.register_component_unique_id(self.Ids.ZONE),
+                        self.register_component_unique_id(self.Ids.ZONE_COL),
+                        self.register_component_unique_id(self.Ids.REGION),
+                        self.register_component_unique_id(self.Ids.REGION_COL),
+                        self.register_component_unique_id(self.Ids.ZONE_REGION),
+                        self.register_component_unique_id(self.Ids.PHASE),
+                        self.register_component_unique_id(self.Ids.PHASE_MENU),
+                        self.register_component_unique_id(self.Ids.CONTAINMENT),
+                        self.register_component_unique_id(self.Ids.CONTAINMENT_MENU),
+                    ],
+                    self._content,
+                )
+            )
+        if self._content["maps"]:
+            menu_layout.append(
+                ExperimentalFeaturesLayout(
+                    self.register_component_unique_id(self.Ids.PLUME_THRESHOLD),
+                    self.register_component_unique_id(self.Ids.PLUME_SMOOTHING),
+                ),
+            )
+        menu_layout += [
             FeedbackLayout(),
             FeedbackButton(),
         ]
+        return menu_layout
 
     def set_callbacks(self) -> None:
         @callback(
@@ -188,7 +198,7 @@ class ViewSettings(SettingsGroupABC):
         def set_realizations(ensemble: str) -> Tuple[List[Dict[str, Any]], List[int]]:
             rlz = [
                 {"value": r, "label": str(r)}
-                for r in self._ensemble_surface_providers[ensemble].realizations()
+                for r in self._realizations_per_ensemble[ensemble]
             ]
             return rlz, [rlz[0]["value"]]  # type: ignore
 
@@ -230,173 +240,220 @@ class ViewSettings(SettingsGroupABC):
                     )
             return formations, picked_formation
 
-        @callback(
-            Output(
-                self.component_unique_id(self.Ids.STATISTIC).to_string(), "disabled"
-            ),
-            Input(self.component_unique_id(self.Ids.REALIZATION).to_string(), "value"),
-            Input(self.component_unique_id(self.Ids.PROPERTY).to_string(), "value"),
-        )
-        def toggle_statistics(realizations: List[int], attribute: str) -> bool:
-            if len(realizations) <= 1:
-                return True
-            if MapType[MapAttribute(attribute).name].value == "PLUME":
-                return True
-            return False
+        if self._content["maps"]:
 
-        @callback(
-            Output(self.component_unique_id(self.Ids.CM_MIN).to_string(), "disabled"),
-            Output(self.component_unique_id(self.Ids.CM_MAX).to_string(), "disabled"),
-            Input(self.component_unique_id(self.Ids.CM_MIN_AUTO).to_string(), "value"),
-            Input(self.component_unique_id(self.Ids.CM_MAX_AUTO).to_string(), "value"),
-        )
-        def set_color_range_data(
-            min_auto: List[str], max_auto: List[str]
-        ) -> Tuple[bool, bool]:
-            return len(min_auto) == 1, len(max_auto) == 1
-
-        @callback(
-            output=[Output(id, "disabled") for id in self._threshold_ids],
-            inputs={
-                "attribute": Input(
-                    self.component_unique_id(self.Ids.PROPERTY).to_string(),
-                    "value",
-                )
-            },
-        )
-        def disable_irrelevant_thresholds(attribute: str) -> List[bool]:
-            return [id != attribute for id in self._threshold_ids]
-
-        @callback(
-            Output(
-                self.component_unique_id(self.Ids.Y_MIN_GRAPH).to_string(), "disabled"
-            ),
-            Output(
-                self.component_unique_id(self.Ids.Y_MAX_GRAPH).to_string(), "disabled"
-            ),
-            Input(
-                self.component_unique_id(self.Ids.Y_MIN_AUTO_GRAPH).to_string(), "value"
-            ),
-            Input(
-                self.component_unique_id(self.Ids.Y_MAX_AUTO_GRAPH).to_string(), "value"
-            ),
-        )
-        def set_y_min_max(
-            min_auto: List[str], max_auto: List[str]
-        ) -> Tuple[bool, bool]:
-            return len(min_auto) == 1, len(max_auto) == 1
-
-        @callback(
-            Output(self.component_unique_id(self.Ids.PHASE).to_string(), "options"),
-            Output(self.component_unique_id(self.Ids.PHASE).to_string(), "value"),
-            Input(self.component_unique_id(self.Ids.GRAPH_SOURCE).to_string(), "value"),
-            Input(self.component_unique_id(self.Ids.ENSEMBLE).to_string(), "value"),
-            State(self.component_unique_id(self.Ids.PHASE).to_string(), "value"),
-        )
-        def set_phases(
-            source: GraphSource,
-            ensemble: str,
-            current_value: str,
-        ) -> Tuple[List[Dict[str, str]], Union[Any, str]]:
-            if ensemble is not None:
-                phases = self._menu_options[ensemble][source]["phases"]
-                options = [{"label": phase.title(), "value": phase} for phase in phases]
-                return options, no_update if current_value in phases else "total"
-            return [{"label": "Total", "value": "total"}], "total"
-
-        @callback(
-            Output(self.component_unique_id(self.Ids.ZONE).to_string(), "options"),
-            Output(self.component_unique_id(self.Ids.ZONE).to_string(), "value"),
-            Input(self.component_unique_id(self.Ids.GRAPH_SOURCE).to_string(), "value"),
-            Input(self.component_unique_id(self.Ids.ENSEMBLE).to_string(), "value"),
-            State(self.component_unique_id(self.Ids.ZONE).to_string(), "value"),
-        )
-        def set_zones(
-            source: GraphSource,
-            ensemble: str,
-            current_value: str,
-        ) -> Tuple[List[Dict[str, str]], Union[Any, str]]:
-            if ensemble is not None:
-                zones = self._menu_options[ensemble][source]["zones"]
-                if len(zones) > 0:
-                    options = [{"label": zone.title(), "value": zone} for zone in zones]
-                    return options, no_update if current_value in zones else "all"
-            return [{"label": "All", "value": "all"}], "all"
-
-        @callback(
-            Output(self.component_unique_id(self.Ids.REGION).to_string(), "options"),
-            Output(self.component_unique_id(self.Ids.REGION).to_string(), "value"),
-            Input(self.component_unique_id(self.Ids.GRAPH_SOURCE).to_string(), "value"),
-            Input(self.component_unique_id(self.Ids.ENSEMBLE).to_string(), "value"),
-            State(self.component_unique_id(self.Ids.REGION).to_string(), "value"),
-        )
-        def set_regions(
-            source: GraphSource,
-            ensemble: str,
-            current_value: str,
-        ) -> Tuple[List[Dict[str, str]], Union[Any, str]]:
-            if ensemble is not None:
-                regions = self._menu_options[ensemble][source]["regions"]
-                if len(regions) > 0:
-                    options = [{"label": reg.title(), "value": reg} for reg in regions]
-                    return options, no_update if current_value in regions else "all"
-            return [{"label": "All", "value": "all"}], "all"
-
-        @callback(
-            Output(
-                self.component_unique_id(self.Ids.MASS_UNIT).to_string(), "disabled"
-            ),
-            Input(self.component_unique_id(self.Ids.PROPERTY).to_string(), "value"),
-        )
-        def toggle_unit(attribute: str) -> bool:
-            if MapType[MapAttribute(attribute).name].value != "MASS":
-                return True
-            return False
-
-        @callback(
-            Output(self.component_unique_id(self.Ids.MARK_BY).to_string(), "options"),
-            Output(self.component_unique_id(self.Ids.MARK_BY).to_string(), "value"),
-            Output(self.component_unique_id(self.Ids.ZONE_COL).to_string(), "style"),
-            Output(self.component_unique_id(self.Ids.REGION_COL).to_string(), "style"),
-            Output(self.component_unique_id(self.Ids.PHASE_MENU).to_string(), "style"),
-            Output(
-                self.component_unique_id(self.Ids.CONTAINMENT_MENU).to_string(),
-                "style",
-            ),
-            Input(self.component_unique_id(self.Ids.COLOR_BY).to_string(), "value"),
-            Input(self.component_unique_id(self.Ids.MARK_BY).to_string(), "value"),
-        )
-        def organize_color_and_mark_menus(
-            color_choice: str,
-            mark_choice: str,
-        ) -> Tuple[List[Dict], str, Dict, Dict, Dict, Dict]:
-            mark_options = [
-                {"label": "Phase", "value": "phase"},
-                {"label": "None", "value": "none"},
-            ]
-            if self._has_zones and color_choice == "containment":
-                mark_options.append({"label": "Zone", "value": "zone"})
-            if self._has_regions and color_choice == "containment":
-                mark_options.append({"label": "Region", "value": "region"})
-            if color_choice in ["zone", "region"]:
-                mark_options.append({"label": "Containment", "value": "containment"})
-            if mark_choice is None or mark_choice == color_choice:
-                mark_choice = "phase"
-            if mark_choice in ["zone", "region"] and color_choice in ["zone", "region"]:
-                mark_choice = "phase"
-            zone, region, phase, containment = _make_styles(
-                color_choice, mark_choice, self._has_zones, self._has_regions
+            @callback(
+                Output(
+                    self.component_unique_id(self.Ids.STATISTIC).to_string(), "disabled"
+                ),
+                Input(
+                    self.component_unique_id(self.Ids.REALIZATION).to_string(), "value"
+                ),
+                Input(self.component_unique_id(self.Ids.PROPERTY).to_string(), "value"),
             )
-            return mark_options, mark_choice, zone, region, phase, containment
+            def toggle_statistics(realizations: List[int], attribute: str) -> bool:
+                if len(realizations) <= 1:
+                    return True
+                if MapType[MapAttribute(attribute).name].value == "PLUME":
+                    return True
+                return False
 
-        @callback(
-            Output(self.component_unique_id(self.Ids.ZONE).to_string(), "disabled"),
-            Output(self.component_unique_id(self.Ids.REGION).to_string(), "disabled"),
-            Input(self.component_unique_id(self.Ids.ZONE).to_string(), "value"),
-            Input(self.component_unique_id(self.Ids.REGION).to_string(), "value"),
-        )
-        def disable_zone_or_region(zone: str, region: str) -> Tuple[bool, bool]:
-            return region != "all", zone != "all"
+            @callback(
+                Output(
+                    self.component_unique_id(self.Ids.CM_MIN).to_string(), "disabled"
+                ),
+                Output(
+                    self.component_unique_id(self.Ids.CM_MAX).to_string(), "disabled"
+                ),
+                Input(
+                    self.component_unique_id(self.Ids.CM_MIN_AUTO).to_string(), "value"
+                ),
+                Input(
+                    self.component_unique_id(self.Ids.CM_MAX_AUTO).to_string(), "value"
+                ),
+            )
+            def set_color_range_data(
+                min_auto: List[str], max_auto: List[str]
+            ) -> Tuple[bool, bool]:
+                return len(min_auto) == 1, len(max_auto) == 1
+
+            @callback(
+                output=[Output(id, "disabled") for id in self._threshold_ids],
+                inputs={
+                    "attribute": Input(
+                        self.component_unique_id(self.Ids.PROPERTY).to_string(),
+                        "value",
+                    )
+                },
+            )
+            def disable_irrelevant_thresholds(attribute: str) -> List[bool]:
+                return [id != attribute for id in self._threshold_ids]
+
+            @callback(
+                Output(
+                    self.component_unique_id(self.Ids.MASS_UNIT).to_string(), "disabled"
+                ),
+                Input(self.component_unique_id(self.Ids.PROPERTY).to_string(), "value"),
+            )
+            def toggle_unit(attribute: str) -> bool:
+                if MapType[MapAttribute(attribute).name].value != "MASS":
+                    return True
+                return False
+
+        if self._content["any_table"]:
+
+            @callback(
+                Output(
+                    self.component_unique_id(self.Ids.Y_MIN_GRAPH).to_string(),
+                    "disabled",
+                ),
+                Output(
+                    self.component_unique_id(self.Ids.Y_MAX_GRAPH).to_string(),
+                    "disabled",
+                ),
+                Input(
+                    self.component_unique_id(self.Ids.Y_MIN_AUTO_GRAPH).to_string(),
+                    "value",
+                ),
+                Input(
+                    self.component_unique_id(self.Ids.Y_MAX_AUTO_GRAPH).to_string(),
+                    "value",
+                ),
+            )
+            def set_y_min_max(
+                min_auto: List[str], max_auto: List[str]
+            ) -> Tuple[bool, bool]:
+                return len(min_auto) == 1, len(max_auto) == 1
+
+            @callback(
+                Output(self.component_unique_id(self.Ids.PHASE).to_string(), "options"),
+                Output(self.component_unique_id(self.Ids.PHASE).to_string(), "value"),
+                Input(
+                    self.component_unique_id(self.Ids.GRAPH_SOURCE).to_string(), "value"
+                ),
+                Input(self.component_unique_id(self.Ids.ENSEMBLE).to_string(), "value"),
+                State(self.component_unique_id(self.Ids.PHASE).to_string(), "value"),
+            )
+            def set_phases(
+                source: GraphSource,
+                ensemble: str,
+                current_value: str,
+            ) -> Tuple[List[Dict[str, str]], Union[Any, str]]:
+                if ensemble is not None:
+                    phases = self._menu_options[ensemble][source]["phases"]
+                    options = [
+                        {"label": phase.title(), "value": phase} for phase in phases
+                    ]
+                    return options, no_update if current_value in phases else "total"
+                return [{"label": "Total", "value": "total"}], "total"
+
+            @callback(
+                Output(self.component_unique_id(self.Ids.ZONE).to_string(), "options"),
+                Output(self.component_unique_id(self.Ids.ZONE).to_string(), "value"),
+                Input(
+                    self.component_unique_id(self.Ids.GRAPH_SOURCE).to_string(), "value"
+                ),
+                Input(self.component_unique_id(self.Ids.ENSEMBLE).to_string(), "value"),
+                State(self.component_unique_id(self.Ids.ZONE).to_string(), "value"),
+            )
+            def set_zones(
+                source: GraphSource,
+                ensemble: str,
+                current_value: str,
+            ) -> Tuple[List[Dict[str, str]], Union[Any, str]]:
+                if ensemble is not None:
+                    zones = self._menu_options[ensemble][source]["zones"]
+                    if len(zones) > 0:
+                        options = [
+                            {"label": zone.title(), "value": zone} for zone in zones
+                        ]
+                        return options, no_update if current_value in zones else "all"
+                return [{"label": "All", "value": "all"}], "all"
+
+            @callback(
+                Output(
+                    self.component_unique_id(self.Ids.REGION).to_string(), "options"
+                ),
+                Output(self.component_unique_id(self.Ids.REGION).to_string(), "value"),
+                Input(
+                    self.component_unique_id(self.Ids.GRAPH_SOURCE).to_string(), "value"
+                ),
+                Input(self.component_unique_id(self.Ids.ENSEMBLE).to_string(), "value"),
+                State(self.component_unique_id(self.Ids.REGION).to_string(), "value"),
+            )
+            def set_regions(
+                source: GraphSource,
+                ensemble: str,
+                current_value: str,
+            ) -> Tuple[List[Dict[str, str]], Union[Any, str]]:
+                if ensemble is not None:
+                    regions = self._menu_options[ensemble][source]["regions"]
+                    if len(regions) > 0:
+                        options = [
+                            {"label": reg.title(), "value": reg} for reg in regions
+                        ]
+                        return options, no_update if current_value in regions else "all"
+                return [{"label": "All", "value": "all"}], "all"
+
+            @callback(
+                Output(
+                    self.component_unique_id(self.Ids.MARK_BY).to_string(), "options"
+                ),
+                Output(self.component_unique_id(self.Ids.MARK_BY).to_string(), "value"),
+                Output(
+                    self.component_unique_id(self.Ids.ZONE_COL).to_string(), "style"
+                ),
+                Output(
+                    self.component_unique_id(self.Ids.REGION_COL).to_string(), "style"
+                ),
+                Output(
+                    self.component_unique_id(self.Ids.PHASE_MENU).to_string(), "style"
+                ),
+                Output(
+                    self.component_unique_id(self.Ids.CONTAINMENT_MENU).to_string(),
+                    "style",
+                ),
+                Input(self.component_unique_id(self.Ids.COLOR_BY).to_string(), "value"),
+                Input(self.component_unique_id(self.Ids.MARK_BY).to_string(), "value"),
+            )
+            def organize_color_and_mark_menus(
+                color_choice: str,
+                mark_choice: str,
+            ) -> Tuple[List[Dict], str, Dict, Dict, Dict, Dict]:
+                mark_options = [
+                    {"label": "Phase", "value": "phase"},
+                    {"label": "None", "value": "none"},
+                ]
+                if self._content["zones"] and color_choice == "containment":
+                    mark_options.append({"label": "Zone", "value": "zone"})
+                if self._content["regions"] and color_choice == "containment":
+                    mark_options.append({"label": "Region", "value": "region"})
+                if color_choice in ["zone", "region"]:
+                    mark_options.append(
+                        {"label": "Containment", "value": "containment"}
+                    )
+                if mark_choice is None or mark_choice == color_choice:
+                    mark_choice = "phase"
+                if mark_choice in ["zone", "region"] and color_choice in [
+                    "zone",
+                    "region",
+                ]:
+                    mark_choice = "phase"
+                zone, region, phase, containment = _make_styles(
+                    color_choice, mark_choice, self._content["zones"], self._content["regions"]
+                )
+                return mark_options, mark_choice, zone, region, phase, containment
+
+            @callback(
+                Output(self.component_unique_id(self.Ids.ZONE).to_string(), "disabled"),
+                Output(
+                    self.component_unique_id(self.Ids.REGION).to_string(), "disabled"
+                ),
+                Input(self.component_unique_id(self.Ids.ZONE).to_string(), "value"),
+                Input(self.component_unique_id(self.Ids.REGION).to_string(), "value"),
+            )
+            def disable_zone_or_region(zone: str, region: str) -> Tuple[bool, bool]:
+                return region != "all", zone != "all"
 
 
 class OpenDialogButton(html.Button):
@@ -689,7 +746,6 @@ class GraphSelectorsLayout(wcc.Selectors):
         "flexDirection": "row",
     }
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         graph_source_id: str,
@@ -697,47 +753,51 @@ class GraphSelectorsLayout(wcc.Selectors):
         y_min_ids: List[str],
         y_max_ids: List[str],
         containment_ids: List[str],
-        has_zones: bool,
-        has_regions: bool,
-        has_unsmry: bool,
+        content: Dict[str, bool],
     ):
-        disp_zone = "flex" if has_zones else "none"
-        disp_region = "flex" if has_regions else "none"
+        disp_zone = "flex" if content["zones"] else "none"
+        disp_region = "flex" if content["regions"] else "none"
         header = "Containment for specific"
-        if has_zones and not has_regions:
+        if content["zones"] and not content["regions"]:
             header += " zone"
-        elif has_regions and not has_zones:
+        elif content["regions"] and not content["zones"]:
             header += " region"
         color_options = [{"label": "Containment (standard)", "value": "containment"}]
         mark_options = [{"label": "Phase", "value": "phase"}]
-        if has_zones:
+        if content["zones"]:
             color_options.append({"label": "Zone", "value": "zone"})
             mark_options.append({"label": "Zone", "value": "zone"})
-        if has_regions:
+        if content["regions"]:
             color_options.append({"label": "Region", "value": "region"})
             mark_options.append({"label": "Region", "value": "region"})
-        source_options = [
-            GraphSource.CONTAINMENT_MASS,
-            GraphSource.CONTAINMENT_ACTUAL_VOLUME,
-        ]
-        if has_unsmry:
+        source_options = []
+        if content["mass"]:
+            source_options.append(GraphSource.CONTAINMENT_MASS)
+        if content["volume"]:
+            source_options.append(GraphSource.CONTAINMENT_ACTUAL_VOLUME)
+        if content["unsmry"]:
             source_options.append(GraphSource.UNSMRY)
+        unit_options, init_unit = (
+            (list(Co2VolumeScale), Co2VolumeScale.BILLION_CUBIC_METERS)
+            if source_options[0] == GraphSource.CONTAINMENT_ACTUAL_VOLUME
+            else (list(Co2MassScale), Co2MassScale.MTONS)
+        )
         super().__init__(
             label="Graph Settings",
-            open_details=False,
+            open_details=not content["maps"],
             children=[
                 "Source",
                 wcc.Dropdown(
                     id=graph_source_id,
                     options=source_options,
-                    value=GraphSource.CONTAINMENT_MASS,
+                    value=source_options[0],
                     clearable=False,
                 ),
                 "Unit",
                 wcc.Dropdown(
                     id=co2_scale_id,
-                    options=list(Co2MassScale),
-                    value=Co2MassScale.MTONS,
+                    options=unit_options,
+                    value=init_unit,
                     clearable=False,
                 ),
                 html.Div(
@@ -774,7 +834,7 @@ class GraphSelectorsLayout(wcc.Selectors):
                         ),
                     ],
                     style={
-                        "display": "flex",  # disp,
+                        "display": "flex",
                         "flex-direction": "row",
                         "margin-top": "10px",
                         "margin-bottom": "1px",
@@ -811,7 +871,7 @@ class GraphSelectorsLayout(wcc.Selectors):
                             ],
                             id=containment_ids[4],
                             style={
-                                "width": "50%" if has_regions else "100%",
+                                "width": "50%" if content["regions"] else "100%",
                                 "display": disp_zone,
                                 "flex-direction": "column",
                             },
@@ -828,7 +888,7 @@ class GraphSelectorsLayout(wcc.Selectors):
                             ],
                             id=containment_ids[6],
                             style={
-                                "width": "50%" if has_zones else "100%",
+                                "width": "50%" if content["zones"] else "100%",
                                 "display": disp_region,
                                 "flex-direction": "column",
                             },


### PR DESCRIPTION
If either maps or tables are missing (meaning that the respective share/results/maps or share/results/tables directory is empty in every realization), only the other is shown. The left-side menu for the missing component is also hidden.
