### PR TITLE
Reorganization of containment plots

### DIFF
--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -274,10 +274,10 @@ class CO2Leakage(WebvizPluginABC):
                 Output(self._view_component(MapViewElement.Ids.BAR_PLOT), "figure"),
                 Output(self._view_component(MapViewElement.Ids.TIME_PLOT), "figure"),
                 # NBNB-third-tab
-                #Output(
+                # Output(
                 #    self._view_component(MapViewElement.Ids.TIME_PLOT_ONE_REAL),
                 #    "figure",
-                #),
+                # ),
                 Input(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
                 Input(self._settings_component(ViewSettings.Ids.GRAPH_SOURCE), "value"),
                 Input(self._settings_component(ViewSettings.Ids.CO2_SCALE), "value"),
@@ -321,7 +321,7 @@ class CO2Leakage(WebvizPluginABC):
                 lines_to_show: str,
             ) -> Tuple[Dict, go.Figure, go.Figure, go.Figure]:
                 # pylint: disable=too-many-locals
-                figs = [no_update] * 2 # 3 # NBNB-third-tab
+                figs = [no_update] * 2  # 3 # NBNB-third-tab
                 cont_info = process_containment_info(
                     zone,
                     region,
@@ -386,7 +386,7 @@ class CO2Leakage(WebvizPluginABC):
                                 self._co2_table_providers[ensemble],
                             )
                             # NBNB-third-tab
-                            #figs[2] = go.Figure()
+                            # figs[2] = go.Figure()
                     else:
                         LOGGER.warning(
                             """UNSMRY file has not been specified as input.
@@ -410,11 +410,17 @@ class CO2Leakage(WebvizPluginABC):
                 return list(Co2MassScale), Co2MassScale.MTONS
 
             @callback(
-                Output(self._settings_component(ViewSettings.Ids.REAL_OR_STAT), "style"),
-                Output(self._settings_component(ViewSettings.Ids.Y_LIM_OPTIONS), "style"),
+                Output(
+                    self._settings_component(ViewSettings.Ids.REAL_OR_STAT), "style"
+                ),
+                Output(
+                    self._settings_component(ViewSettings.Ids.Y_LIM_OPTIONS), "style"
+                ),
                 Input(self._settings_component(ViewSettings.Ids.REALIZATION), "value"),
             )
-            def toggle_time_plot_options_visibility(realizations: List[int]) -> List[Dict[str, str]]:
+            def toggle_time_plot_options_visibility(
+                realizations: List[int],
+            ) -> Tuple[Dict[str, str], Dict[str, str]]:
                 if len(realizations) == 1:
                     return (
                         {"display": "none"},
@@ -580,7 +586,7 @@ class CO2Leakage(WebvizPluginABC):
                 ensemble: str,
                 current_views: List[Any],
                 thresholds: List[float],
-            ) -> Tuple[List[Dict[Any, Any]], List[Any], Dict[Any, Any]]:
+            ) -> Tuple[List[Dict[Any, Any]], Optional[List[Any]], Dict[Any, Any]]:
                 # Unable to clear cache (when needed) without the protected member
                 # pylint: disable=protected-access
                 current_thresholds = dict(zip(self._threshold_ids, thresholds))
@@ -724,9 +730,9 @@ class CO2Leakage(WebvizPluginABC):
                 ),
                 Output(self._view_component(MapViewElement.Ids.BAR_PLOT), "style"),
                 Output(self._view_component(MapViewElement.Ids.TIME_PLOT), "style"),
-                #Output(
+                # Output(
                 #    self._view_component(MapViewElement.Ids.TIME_PLOT_ONE_REAL), "style"
-                #), # NBNB-third-tab
+                # ), # NBNB-third-tab
                 Input(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
                 Input(self._view_component(MapViewElement.Ids.SIZE_SLIDER), "value"),
                 State(self._view_component(MapViewElement.Ids.TOP_ELEMENT), "style"),
@@ -743,18 +749,20 @@ class CO2Leakage(WebvizPluginABC):
                 bottom_style["height"] = f"{slider_value}vh"
                 top_style["height"] = f"{80 - slider_value}vh"
 
-                styles = [{"height": f"{slider_value * 0.9 - 4}vh", "width": "90%"}] * 2 # 3 # NBNB-third-tab
+                styles = [
+                    {"height": f"{slider_value * 0.9 - 4}vh", "width": "90%"}
+                ] * 2  # 3 # NBNB-third-tab
                 if source == GraphSource.UNSMRY and self._unsmry_providers is None:
-                    styles = [{"display": "none"}] * 2 # 3 # NBNB-third-tab
+                    styles = [{"display": "none"}] * 2  # 3 # NBNB-third-tab
                 elif (
                     source == GraphSource.CONTAINMENT_MASS
                     and ensemble not in self._co2_table_providers
                 ):
-                    styles = [{"display": "none"}] * 2 # 3 # NBNB-third-tab
+                    styles = [{"display": "none"}] * 2  # 3 # NBNB-third-tab
                 elif (
                     source == GraphSource.CONTAINMENT_ACTUAL_VOLUME
                     and ensemble not in self._co2_actual_volume_table_providers
                 ):
-                    styles = [{"display": "none"}] * 2 # 3 # NBNB-third-tab
+                    styles = [{"display": "none"}] * 2  # 3 # NBNB-third-tab
 
                 return [top_style, bottom_style] + styles

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -17,6 +17,7 @@ from webviz_subsurface.plugins._co2_leakage._utilities.callbacks import (
     generate_containment_figures,
     generate_unsmry_figures,
     get_plume_polygon,
+    make_plot_ids,
     process_containment_info,
     process_summed_mass,
     process_visualization_info,
@@ -192,6 +193,7 @@ class CO2Leakage(WebvizPluginABC):
             "change": False,
             "unit": "tons",
         }
+        self._plot_id = ""
         self._color_tables = co2leakage_color_tables()
         self._well_pick_names: Dict[str, List[str]] = {
             ens: (
@@ -271,10 +273,11 @@ class CO2Leakage(WebvizPluginABC):
             @callback(
                 Output(self._view_component(MapViewElement.Ids.BAR_PLOT), "figure"),
                 Output(self._view_component(MapViewElement.Ids.TIME_PLOT), "figure"),
-                Output(
-                    self._view_component(MapViewElement.Ids.TIME_PLOT_ONE_REAL),
-                    "figure",
-                ),
+                # NBNB-third-tab
+                #Output(
+                #    self._view_component(MapViewElement.Ids.TIME_PLOT_ONE_REAL),
+                #    "figure",
+                #),
                 Input(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
                 Input(self._settings_component(ViewSettings.Ids.GRAPH_SOURCE), "value"),
                 Input(self._settings_component(ViewSettings.Ids.CO2_SCALE), "value"),
@@ -295,6 +298,7 @@ class CO2Leakage(WebvizPluginABC):
                 Input(self._settings_component(ViewSettings.Ids.COLOR_BY), "value"),
                 Input(self._settings_component(ViewSettings.Ids.MARK_BY), "value"),
                 Input(self._settings_component(ViewSettings.Ids.SORT_PLOT), "value"),
+                Input(self._settings_component(ViewSettings.Ids.REAL_OR_STAT), "value"),
             )
             @callback_typecheck
             def update_graphs(
@@ -314,9 +318,10 @@ class CO2Leakage(WebvizPluginABC):
                 color_choice: str,
                 mark_choice: Optional[str],
                 sorting: str,
+                lines_to_show: str,
             ) -> Tuple[Dict, go.Figure, go.Figure, go.Figure]:
                 # pylint: disable=too-many-locals
-                figs = [no_update] * 3
+                figs = [no_update] * 2 # 3 # NBNB-third-tab
                 cont_info = process_containment_info(
                     zone,
                     region,
@@ -326,12 +331,24 @@ class CO2Leakage(WebvizPluginABC):
                     color_choice,
                     mark_choice,
                     sorting,
+                    lines_to_show,
                     self._menu_options[ensemble][source],
                 )
                 if source in [
                     GraphSource.CONTAINMENT_MASS,
                     GraphSource.CONTAINMENT_ACTUAL_VOLUME,
                 ]:
+                    plot_ids = make_plot_ids(
+                        ensemble,
+                        source,
+                        co2_scale,
+                        cont_info,
+                        realizations,
+                        lines_to_show,
+                        len(figs),
+                    )
+                    cont_info["update_first_figure"] = self._plot_id != plot_ids[0]
+                    self._plot_id = plot_ids[0]
                     y_limits = [
                         y_min_val if len(y_min_auto) == 0 else None,
                         y_max_val if len(y_max_auto) == 0 else None,
@@ -343,7 +360,7 @@ class CO2Leakage(WebvizPluginABC):
                         figs[: len(figs)] = generate_containment_figures(
                             self._co2_table_providers[ensemble],
                             co2_scale,
-                            realizations[0],
+                            realizations,
                             y_limits,
                             cont_info,
                         )
@@ -354,11 +371,11 @@ class CO2Leakage(WebvizPluginABC):
                         figs[: len(figs)] = generate_containment_figures(
                             self._co2_actual_volume_table_providers[ensemble],
                             co2_scale,
-                            realizations[0],
+                            realizations,
                             y_limits,
                             cont_info,
                         )
-                    set_plot_ids(figs, source, co2_scale, cont_info, realizations)
+                    set_plot_ids(figs, plot_ids)
                 elif source == GraphSource.UNSMRY:
                     if self._unsmry_providers is not None:
                         if ensemble in self._unsmry_providers:
@@ -368,7 +385,8 @@ class CO2Leakage(WebvizPluginABC):
                                 co2_scale,
                                 self._co2_table_providers[ensemble],
                             )
-                            figs[2] = go.Figure()
+                            # NBNB-third-tab
+                            #figs[2] = go.Figure()
                     else:
                         LOGGER.warning(
                             """UNSMRY file has not been specified as input.
@@ -390,6 +408,22 @@ class CO2Leakage(WebvizPluginABC):
                 if attribute == GraphSource.CONTAINMENT_ACTUAL_VOLUME:
                     return list(Co2VolumeScale), Co2VolumeScale.BILLION_CUBIC_METERS
                 return list(Co2MassScale), Co2MassScale.MTONS
+
+            @callback(
+                Output(self._settings_component(ViewSettings.Ids.REAL_OR_STAT), "style"),
+                Output(self._settings_component(ViewSettings.Ids.Y_LIM_OPTIONS), "style"),
+                Input(self._settings_component(ViewSettings.Ids.REALIZATION), "value"),
+            )
+            def toggle_time_plot_options_visibility(realizations: List[int]) -> List[Dict[str, str]]:
+                if len(realizations) == 1:
+                    return (
+                        {"display": "none"},
+                        {"display": "flex", "flex-direction": "column"},
+                    )
+                return (
+                    {"display": "flex", "flex-direction": "row"},
+                    {"display": "none"},
+                )
 
         if self._content["maps"]:
 
@@ -690,9 +724,9 @@ class CO2Leakage(WebvizPluginABC):
                 ),
                 Output(self._view_component(MapViewElement.Ids.BAR_PLOT), "style"),
                 Output(self._view_component(MapViewElement.Ids.TIME_PLOT), "style"),
-                Output(
-                    self._view_component(MapViewElement.Ids.TIME_PLOT_ONE_REAL), "style"
-                ),
+                #Output(
+                #    self._view_component(MapViewElement.Ids.TIME_PLOT_ONE_REAL), "style"
+                #), # NBNB-third-tab
                 Input(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
                 Input(self._view_component(MapViewElement.Ids.SIZE_SLIDER), "value"),
                 State(self._view_component(MapViewElement.Ids.TOP_ELEMENT), "style"),
@@ -709,18 +743,18 @@ class CO2Leakage(WebvizPluginABC):
                 bottom_style["height"] = f"{slider_value}vh"
                 top_style["height"] = f"{80 - slider_value}vh"
 
-                styles = [{"height": f"{slider_value * 0.9 - 4}vh", "width": "90%"}] * 3
+                styles = [{"height": f"{slider_value * 0.9 - 4}vh", "width": "90%"}] * 2 # 3 # NBNB-third-tab
                 if source == GraphSource.UNSMRY and self._unsmry_providers is None:
-                    styles = [{"display": "none"}] * 3
+                    styles = [{"display": "none"}] * 2 # 3 # NBNB-third-tab
                 elif (
                     source == GraphSource.CONTAINMENT_MASS
                     and ensemble not in self._co2_table_providers
                 ):
-                    styles = [{"display": "none"}] * 3
+                    styles = [{"display": "none"}] * 2 # 3 # NBNB-third-tab
                 elif (
                     source == GraphSource.CONTAINMENT_ACTUAL_VOLUME
                     and ensemble not in self._co2_actual_volume_table_providers
                 ):
-                    styles = [{"display": "none"}] * 3
+                    styles = [{"display": "none"}] * 2 # 3 # NBNB-third-tab
 
                 return [top_style, bottom_style] + styles

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -371,30 +371,43 @@ def create_map_layers(
 def generate_containment_figures(
     table_provider: ContainmentDataProvider,
     co2_scale: Union[Co2MassScale, Co2VolumeScale],
-    realization: int,
+    realizations: List[int],
     y_limits: List[Optional[float]],
     containment_info: Dict[str, Union[str, None, List[str], int]],
 ) -> Tuple[go.Figure, go.Figure, go.Figure]:
     try:
-        fig0 = generate_co2_volume_figure(
-            table_provider,
-            table_provider.realizations,
-            co2_scale,
-            containment_info,
+        fig0 = (
+            no_update
+            if not containment_info["update_first_figure"]
+            else generate_co2_volume_figure(
+                table_provider,
+                table_provider.realizations,
+                co2_scale,
+                containment_info,
+            )
         )
-        fig1 = generate_co2_time_containment_figure(
-            table_provider,
-            table_provider.realizations,
-            co2_scale,
-            containment_info,
+        fig1 = (
+            generate_co2_time_containment_figure(
+                table_provider,
+                realizations,
+                co2_scale,
+                containment_info,
+            )
+            if len(realizations) > 1
+            else generate_co2_time_containment_one_realization_figure(
+                table_provider,
+                co2_scale,
+                realizations[0],
+                y_limits,
+                containment_info,
+            )
         )
-        fig2 = generate_co2_time_containment_one_realization_figure(
-            table_provider, co2_scale, realization, y_limits, containment_info
-        )
+        #fig2 = go.Figure()
+        # NBNB-third-tab
     except KeyError as exc:
         warnings.warn(f"Could not generate CO2 figures: {exc}")
         raise exc
-    return fig0, fig1, fig2
+    return fig0, fig1#, fig2 # NBNB-third-tab
 
 
 def generate_unsmry_figures(
@@ -420,10 +433,11 @@ def process_visualization_info(
     Clear surface cache if the threshold for visualization or mass unit is changed
     """
     stored_info["attribute"] = attribute
-    if MapType[MapAttribute(attribute).name].value in ["PLUME", "MIGRATION_TIME"]:
-        return stored_info
     stored_info["change"] = False
-    if unit != stored_info["unit"]:
+    if (
+        MapType[MapAttribute(attribute).name].value not in ["PLUME", "MIGRATION_TIME"]
+        and unit != stored_info["unit"]
+    ):
         stored_info["unit"] = unit
         stored_info["change"] = True
     if thresholds is not None:
@@ -445,6 +459,7 @@ def process_containment_info(
     color_choice: str,
     mark_choice: Optional[str],
     sorting: str,
+    lines_to_show: str,
     menu_options: MenuOptions,
 ) -> Dict[str, Union[str, None, List[str], int]]:
     if mark_choice is None:
@@ -487,46 +502,65 @@ def process_containment_info(
         "phases": phases,
         "containments": containments,
         "plume_groups": plume_groups,
+        "lines_to_show": lines_to_show,
     }
 
 
-def set_plot_ids(
-    figs: List[go.Figure],
+def make_plot_ids(
+    ensemble: str,
     source: GraphSource,
     scale: Union[Co2MassScale, Co2VolumeScale],
     containment_info: Dict,
     realizations: List[int],
-) -> None:
-    if figs[0] != no_update:
-        zone_str = (
-            containment_info["zone"] if containment_info["zone"] is not None else "None"
+    lines_to_show: str,
+    num_figs: int,
+) -> List[str]:
+    zone_str = (
+        containment_info["zone"] if containment_info["zone"] is not None else "None"
+    )
+    region_str = (
+        containment_info["region"]
+        if containment_info["region"] is not None
+        else "None"
+    )
+    plume_group_str = (
+        containment_info["plume_group"]
+        if containment_info["plume_group"] is not None
+        else "None"
+    )
+    mark_choice_str = (
+        containment_info["mark_choice"]
+        if containment_info["mark_choice"] is not None
+        else "None"
+    )
+    plot_id = "-".join(
+        (
+            ensemble,
+            source,
+            scale,
+            zone_str,
+            region_str,
+            plume_group_str,
+            str(containment_info["phase"]),
+            str(containment_info["containment"]),
+            containment_info["color_choice"],
+            mark_choice_str,
+            containment_info["sorting"],
         )
-        region_str = (
-            containment_info["region"]
-            if containment_info["region"] is not None
-            else "None"
-        )
-        plume_group_str = (
-            containment_info["plume_group"]
-            if containment_info["plume_group"] is not None
-            else "None"
-        )
-        plot_id = "-".join(
-            (
-                source,
-                scale,
-                zone_str,
-                region_str,
-                plume_group_str,
-                str(containment_info["phase"]),
-                str(containment_info["containment"]),
-                containment_info["color_choice"],
-                containment_info["mark_choice"],
-            )
-        )
-        for fig in figs:
-            fig["layout"]["uirevision"] = plot_id
-        figs[-1]["layout"]["uirevision"] += f"-{realizations}"
+    )
+    ids = [plot_id]
+    ids += [plot_id + f"-{realizations}"] * (num_figs - 1)
+    ids[1] += f"-{lines_to_show}"
+    return ids
+
+
+def set_plot_ids(
+    figs: List[go.Figure],
+    ids: List[str],
+):
+    for fig, id in zip(figs, ids):
+        if fig != no_update:
+            fig["layout"]["uirevision"] = id
 
 
 def process_summed_mass(

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -374,7 +374,7 @@ def generate_containment_figures(
     realizations: List[int],
     y_limits: List[Optional[float]],
     containment_info: Dict[str, Union[str, None, List[str], int]],
-) -> Tuple[go.Figure, go.Figure, go.Figure]:
+) -> Tuple[go.Figure, go.Figure]:  # , go.Figure]: # NBNB-third-tab
     try:
         fig0 = (
             no_update
@@ -402,12 +402,12 @@ def generate_containment_figures(
                 containment_info,
             )
         )
-        #fig2 = go.Figure()
+        # fig2 = go.Figure()
         # NBNB-third-tab
     except KeyError as exc:
         warnings.warn(f"Could not generate CO2 figures: {exc}")
         raise exc
-    return fig0, fig1#, fig2 # NBNB-third-tab
+    return fig0, fig1  # , fig2 # NBNB-third-tab
 
 
 def generate_unsmry_figures(
@@ -474,11 +474,10 @@ def process_containment_info(
     if len(plume_groups) > 0:
         plume_groups = [pg_name for pg_name in plume_groups if pg_name != "all"]
 
-        def plume_sort_key(name: str):
+        def plume_sort_key(name: str) -> int:
             if name == "?":
                 return 999
-            else:
-                return name.count("+")
+            return name.count("+")
 
         plume_groups = sorted(plume_groups, key=plume_sort_key)
 
@@ -502,7 +501,7 @@ def process_containment_info(
         "phases": phases,
         "containments": containments,
         "plume_groups": plume_groups,
-        "lines_to_show": lines_to_show,
+        "use_stats": lines_to_show == "stat",
     }
 
 
@@ -519,9 +518,7 @@ def make_plot_ids(
         containment_info["zone"] if containment_info["zone"] is not None else "None"
     )
     region_str = (
-        containment_info["region"]
-        if containment_info["region"] is not None
-        else "None"
+        containment_info["region"] if containment_info["region"] is not None else "None"
     )
     plume_group_str = (
         containment_info["plume_group"]
@@ -556,11 +553,11 @@ def make_plot_ids(
 
 def set_plot_ids(
     figs: List[go.Figure],
-    ids: List[str],
-):
-    for fig, id in zip(figs, ids):
+    plot_ids: List[str],
+) -> None:
+    for fig, plot_id in zip(figs, plot_ids):
         if fig != no_update:
-            fig["layout"]["uirevision"] = id
+            fig["layout"]["uirevision"] = plot_id
 
 
 def process_summed_mass(

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
@@ -44,6 +44,26 @@ _COLOR_ZONES = [
     "#34b36f",
 ]
 
+_LIGHTER_COLORS = {
+    "black": "#909090",
+    "#222222": "#909090",
+    "#00aa00": "#55ff55",
+    "#006ddd": "#6eb6ff",
+    "#dd4300": "#ff9a6e",
+    "#e91451": "#f589a8",
+    "#daa218": "#f2d386",
+    "#208eb7": "#81cde9",
+    "#84bc04": "#cdfc63",
+    "#b74532": "#e19e92",
+    "#9a89b4": "#ccc4d9",
+    "#8d30ba": "#c891e3",
+    "#256b33": "#77d089",
+    "#95704d": "#cfb7a1",
+    "#1357ca": "#7ba7f3",
+    "#f75ef0": "#fbaef7",
+    "#34b36f": "#93e0b7",
+}
+
 
 def _read_dataframe(
     table_provider: EnsembleTableProvider,
@@ -655,6 +675,7 @@ def generate_co2_time_containment_figure(
             "Statistic: %{meta[0]}"
         )
     for rlz in realizations:
+        lwd = 1.5 if rlz in ["p10", "p90"] else 2.5
         sub_df = df[df["realization"] == rlz].copy().reset_index(drop=True)
         if not containment_info["use_stats"]:
             _add_prop_to_df(
@@ -669,7 +690,10 @@ def generate_co2_time_containment_figure(
         ):
             args = {
                 "line_dash": line_type,
-                "marker_color": color,
+                "line_width": lwd,
+                "marker_color": (
+                    _LIGHTER_COLORS[color] if rlz in ["p10", "p90"] else color
+                ),
                 "legendgroup": name,
                 "name": "",
                 "meta": [rlz, name],

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/containment_data_provider.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/containment_data_provider.py
@@ -77,8 +77,8 @@ class ContainmentDataProvider:
     def _get_menu_options(provider: EnsembleTableProvider) -> MenuOptions:
         col_names = provider.column_names()
         realization = provider.realizations()[0]
-        #NBNB: Check that these are the same for all realizations????
-        #NBNB: WARNING and empty for zones / regions, and Error if phases are different?
+        # NBNB: Check that these are the same for all realizations????
+        # NBNB: WARNING and empty for zones / regions, and Error if phases are different?
         df = provider.get_column_data(col_names, [realization])
         zones = ["all"]
         for zone in list(df["zone"]):
@@ -93,11 +93,10 @@ class ContainmentDataProvider:
             if plume_group not in plume_groups:
                 plume_groups.append(plume_group)
 
-        def plume_sort_key(name: str):
+        def plume_sort_key(name: str) -> int:
             if name == "?":
                 return 999
-            else:
-                return name.count("+")
+            return name.count("+")
 
         plume_groups = sorted(plume_groups, key=plume_sort_key)
 

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/containment_data_provider.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/containment_data_provider.py
@@ -77,6 +77,8 @@ class ContainmentDataProvider:
     def _get_menu_options(provider: EnsembleTableProvider) -> MenuOptions:
         col_names = provider.column_names()
         realization = provider.realizations()[0]
+        #NBNB: Check that these are the same for all realizations????
+        #NBNB: WARNING and empty for zones / regions, and Error if phases are different?
         df = provider.get_column_data(col_names, [realization])
         zones = ["all"]
         for zone in list(df["zone"]):

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -138,6 +138,7 @@ class LayoutLabels(StrEnum):
     FEEDBACK = "User feedback"
     VISUALIZATION_UPDATE = "Update threshold"
     VISUALIZATION_THRESHOLDS = "Manage visualization filter"
+    ALL_REAL = "Select all"
 
 
 # pylint: disable=too-few-public-methods
@@ -149,6 +150,13 @@ class LayoutStyle:
         "width": "100%",
         "height": "30px",
         "line-height": "30px",
+        "background-color": "lightgrey",
+    }
+
+    ALL_REAL_BUTTON = {
+        "marginLeft": "10px",
+        "height": "25px",
+        "line-height": "25px",
         "background-color": "lightgrey",
     }
 

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -1,4 +1,7 @@
-from __future__ import annotations  # Change to import Self from typing if we update to Python >3.11
+from __future__ import (  # Change to import Self from typing if we update to Python >3.11
+    annotations,
+)
+
 from typing import Dict, List, TypedDict
 
 from webviz_subsurface._utils.enum_shim import StrEnum

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -1,3 +1,4 @@
+from __future__ import annotations  # Change to import Self from typing if we update to Python >3.11
 from typing import Dict, List, TypedDict
 
 from webviz_subsurface._utils.enum_shim import StrEnum

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
@@ -50,7 +50,10 @@ def publish_and_get_surface_metadata(
     map_attribute_names: FilteredMapAttribute,
 ) -> Tuple[Optional[SurfaceImageMeta], Optional[str], Optional[Any]]:
     if isinstance(address, TruncatedSurfaceAddress):
-        return *_publish_and_get_truncated_surface_metadata(server, provider, address), None
+        return (
+            *_publish_and_get_truncated_surface_metadata(server, provider, address),
+            None,
+        )
     provider_id: str = provider.provider_id()
     qualified_address = QualifiedSurfaceAddress(provider_id, address)
     surf_meta = server.get_surface_metadata(qualified_address)

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/surface_publishing.py
@@ -50,7 +50,7 @@ def publish_and_get_surface_metadata(
     map_attribute_names: FilteredMapAttribute,
 ) -> Tuple[Optional[SurfaceImageMeta], Optional[str], Optional[Any]]:
     if isinstance(address, TruncatedSurfaceAddress):
-        return _publish_and_get_truncated_surface_metadata(server, provider, address)
+        return *_publish_and_get_truncated_surface_metadata(server, provider, address), None
     provider_id: str = provider.provider_id()
     qualified_address = QualifiedSurfaceAddress(provider_id, address)
     surf_meta = server.get_surface_metadata(qualified_address)
@@ -93,7 +93,7 @@ def _publish_and_get_truncated_surface_metadata(
     server: SurfaceImageServer,
     provider: EnsembleSurfaceProvider,
     address: TruncatedSurfaceAddress,
-) -> Tuple[Optional[SurfaceImageMeta], str, Optional[Any]]:
+) -> Tuple[Optional[SurfaceImageMeta], str]:
     qualified_address = QualifiedSurfaceAddress(
         provider.provider_id(),
         # TODO: Should probably use a dedicated address type for this. Statistical surface
@@ -109,15 +109,13 @@ def _publish_and_get_truncated_surface_metadata(
         ),
     )
     surf_meta = server.get_surface_metadata(qualified_address)
-    summed_mass = None
     if surf_meta is None:
         surface = _generate_surface(provider, address)
         if surface is None:
             raise ValueError(f"Could not generate surface for address: {address}")
-        summed_mass = np.ma.sum(surface.values)
         server.publish_surface(qualified_address, surface)
         surf_meta = server.get_surface_metadata(qualified_address)
-    return surf_meta, server.encode_partial_url(qualified_address), summed_mass
+    return surf_meta, server.encode_partial_url(qualified_address)
 
 
 def _generate_surface(

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/unsmry_data_provider.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/unsmry_data_provider.py
@@ -35,6 +35,7 @@ class UnsmryDataProvider:
             "zones": [],
             "regions": [],
             "phases": ["total", "gas", "aqueous"],
+            "plume_groups": [],
         }
 
     @property

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
@@ -26,7 +26,7 @@ class MapViewElement(ViewElementABC):
         DATE_WRAPPER = "date-wrapper"
         BAR_PLOT = "bar-plot"
         TIME_PLOT = "time-plot"
-        TIME_PLOT_ONE_REAL = "time-plot-one-realization"
+        #TIME_PLOT_ONE_REAL = "time-plot-one-realization" # NBNB-third-tab
         BAR_PLOT_ORDER = "bar-plot-order"
         CONTAINMENT_COLORS = "containment-order"
         SIZE_SLIDER = "size-slider"
@@ -99,9 +99,9 @@ class MapViewElement(ViewElementABC):
                             _summary_graph_layout(
                                 self.register_component_unique_id(self.Ids.BAR_PLOT),
                                 self.register_component_unique_id(self.Ids.TIME_PLOT),
-                                self.register_component_unique_id(
-                                    self.Ids.TIME_PLOT_ONE_REAL
-                                ),
+                                #self.register_component_unique_id(
+                                #    self.Ids.TIME_PLOT_ONE_REAL
+                                #), # NBNB-third-tab
                             )
                         ),
                     ],
@@ -143,7 +143,7 @@ class MapViewElement(ViewElementABC):
 def _summary_graph_layout(
     bar_plot_id: str,
     time_plot_id: str,
-    time_plot_one_realization_id: str,
+    #time_plot_one_realization_id: str, # NBNB-third-tab
 ) -> List:
     return [
         wcc.Tabs(
@@ -151,7 +151,7 @@ def _summary_graph_layout(
             value="tab-1",
             children=[
                 wcc.Tab(
-                    label="End-state containment (all realizations)",
+                    label="End-state containment",
                     value="tab-1",
                     children=[
                         html.Div(
@@ -166,7 +166,7 @@ def _summary_graph_layout(
                     ],
                 ),
                 wcc.Tab(
-                    label="Containment over time (all realizations)",
+                    label="Containment over time",
                     value="tab-2",
                     children=[
                         html.Div(
@@ -180,21 +180,22 @@ def _summary_graph_layout(
                         ),
                     ],
                 ),
-                wcc.Tab(
-                    label="Containment over time (one realization)",
-                    value="tab-3",
-                    children=[
-                        html.Div(
-                            wcc.Graph(
-                                id=time_plot_one_realization_id,
-                                figure=go.Figure(),
-                                config={
-                                    "displayModeBar": False,
-                                },
-                            ),
-                        ),
-                    ],
-                ),
+                #NBNB-third-tab
+                #wcc.Tab(
+                #    label="Placeholder",
+                #    value="tab-3",
+                #    children=[
+                #        html.Div(
+                #            wcc.Graph(
+                #                id=time_plot_one_realization_id,
+                #                figure=go.Figure(),
+                #                config={
+                #                    "displayModeBar": False,
+                #                },
+                #            ),
+                #        ),
+                #    ],
+                #),
             ],
         ),
     ]

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
@@ -26,7 +26,7 @@ class MapViewElement(ViewElementABC):
         DATE_WRAPPER = "date-wrapper"
         BAR_PLOT = "bar-plot"
         TIME_PLOT = "time-plot"
-        #TIME_PLOT_ONE_REAL = "time-plot-one-realization" # NBNB-third-tab
+        # TIME_PLOT_ONE_REAL = "time-plot-one-realization" # NBNB-third-tab
         BAR_PLOT_ORDER = "bar-plot-order"
         CONTAINMENT_COLORS = "containment-order"
         SIZE_SLIDER = "size-slider"
@@ -99,9 +99,9 @@ class MapViewElement(ViewElementABC):
                             _summary_graph_layout(
                                 self.register_component_unique_id(self.Ids.BAR_PLOT),
                                 self.register_component_unique_id(self.Ids.TIME_PLOT),
-                                #self.register_component_unique_id(
+                                # self.register_component_unique_id(
                                 #    self.Ids.TIME_PLOT_ONE_REAL
-                                #), # NBNB-third-tab
+                                # ), # NBNB-third-tab
                             )
                         ),
                     ],
@@ -143,7 +143,7 @@ class MapViewElement(ViewElementABC):
 def _summary_graph_layout(
     bar_plot_id: str,
     time_plot_id: str,
-    #time_plot_one_realization_id: str, # NBNB-third-tab
+    # time_plot_one_realization_id: str, # NBNB-third-tab
 ) -> List:
     return [
         wcc.Tabs(
@@ -180,8 +180,8 @@ def _summary_graph_layout(
                         ),
                     ],
                 ),
-                #NBNB-third-tab
-                #wcc.Tab(
+                # NBNB-third-tab
+                # wcc.Tab(
                 #    label="Placeholder",
                 #    value="tab-3",
                 #    children=[
@@ -195,7 +195,7 @@ def _summary_graph_layout(
                 #            ),
                 #        ),
                 #    ],
-                #),
+                # ),
             ],
         ),
     ]

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -197,7 +197,9 @@ class ViewSettings(SettingsGroupABC):
         ]
         return menu_layout
 
+    # pylint: disable=too-many-statements
     def set_callbacks(self) -> None:
+        # pylint: disable=unused-argument
         @callback(
             Output(
                 self.component_unique_id(self.Ids.REALIZATION).to_string(), "options"
@@ -939,12 +941,17 @@ class GraphSelectorsLayout(wcc.Selectors):
                             ],
                             id=containment_ids[4],
                             style={
-                                "width": "33%"
-                                if (content["regions"] and content["plume_groups"])
-                                else (
-                                    "50%"
-                                    if (content["regions"] or content["plume_groups"])
-                                    else "100%"
+                                "width": (
+                                    "33%"
+                                    if (content["regions"] and content["plume_groups"])
+                                    else (
+                                        "50%"
+                                        if (
+                                            content["regions"]
+                                            or content["plume_groups"]
+                                        )
+                                        else "100%"
+                                    )
                                 ),
                                 "display": disp_zone,
                                 "flex-direction": "column",
@@ -962,12 +969,14 @@ class GraphSelectorsLayout(wcc.Selectors):
                             ],
                             id=containment_ids[6],
                             style={
-                                "width": "33%"
-                                if (content["zones"] and content["plume_groups"])
-                                else (
-                                    "50%"
-                                    if (content["zones"] or content["plume_groups"])
-                                    else "100%"
+                                "width": (
+                                    "33%"
+                                    if (content["zones"] and content["plume_groups"])
+                                    else (
+                                        "50%"
+                                        if (content["zones"] or content["plume_groups"])
+                                        else "100%"
+                                    )
                                 ),
                                 "display": disp_region,
                                 "flex-direction": "column",
@@ -1016,12 +1025,14 @@ class GraphSelectorsLayout(wcc.Selectors):
                             ],
                             id=containment_ids[13],
                             style={
-                                "width": "33%"
-                                if (content["zones"] and content["regions"])
-                                else (
-                                    "50%"
-                                    if (content["zones"] or content["regions"])
-                                    else "100%"
+                                "width": (
+                                    "33%"
+                                    if (content["zones"] and content["regions"])
+                                    else (
+                                        "50%"
+                                        if (content["zones"] or content["regions"])
+                                        else "100%"
+                                    )
                                 ),
                                 "display": disp_plume_group,
                                 "flex-direction": "column",
@@ -1040,7 +1051,8 @@ class GraphSelectorsLayout(wcc.Selectors):
                         dcc.RadioItems(
                             options=[
                                 {"label": "Realizations", "value": "real"},
-                                {"label": "Mean/P10/P90", "value": "stat"}],
+                                {"label": "Mean/P10/P90", "value": "stat"},
+                            ],
                             value="real",
                             id=containment_ids[14],
                             inline=True,
@@ -1131,11 +1143,11 @@ class ExperimentalFeaturesLayout(wcc.Selectors):
 
 class EnsembleSelectorLayout(wcc.Selectors):
     def __init__(
-            self,
-            ensemble_id: str,
-            realization_id: str,
-            all_real_id: str,
-            ensembles: List[str],
+        self,
+        ensemble_id: str,
+        realization_id: str,
+        all_real_id: str,
+        ensembles: List[str],
     ):
         super().__init__(
             label="Ensemble",
@@ -1156,12 +1168,12 @@ class EnsembleSelectorLayout(wcc.Selectors):
                             options=["Select all"],
                             value=[],
                             id=all_real_id,
-                        )
+                        ),
                     ],
                     style={
                         "display": "flex",
                         "flex-direction": "row",
-                    }
+                    },
                 ),
                 wcc.SelectWithLabel(
                     id=realization_id,
@@ -1263,6 +1275,7 @@ def get_emails() -> str:
     return ";".join(emails[:2]) + "?cc=" + ";".join(emails[2:])
 
 
+# pylint: disable=too-many-statements, too-many-branches
 def _make_styles(
     color_choice: str,
     mark_choice: str,

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -205,19 +205,18 @@ class ViewSettings(SettingsGroupABC):
                 self.component_unique_id(self.Ids.REALIZATION).to_string(), "options"
             ),
             Output(self.component_unique_id(self.Ids.REALIZATION).to_string(), "value"),
-            Output(self.component_unique_id(self.Ids.ALL_REAL).to_string(), "value"),
             Input(self.component_unique_id(self.Ids.ENSEMBLE).to_string(), "value"),
-            Input(self.component_unique_id(self.Ids.ALL_REAL).to_string(), "value"),
+            Input(self.component_unique_id(self.Ids.ALL_REAL).to_string(), "n_clicks"),
         )
         def set_realizations(
             ensemble: str,
-            select_all: List[str],
+            select_all: int,
         ) -> Tuple[List[Dict[str, Any]], List[int]]:
             rlz = [
                 {"value": r, "label": str(r)}
                 for r in self._realizations_per_ensemble[ensemble]
             ]
-            return rlz, self._realizations_per_ensemble[ensemble], []  # type: ignore
+            return rlz, self._realizations_per_ensemble[ensemble]  # type: ignore
 
         @callback(
             Output(self.component_unique_id(self.Ids.FORMATION).to_string(), "options"),
@@ -1162,17 +1161,19 @@ class EnsembleSelectorLayout(wcc.Selectors):
                 ),
                 html.Div(
                     [
-                        "Realization",
-                        html.Div("", style={"width": "25px"}),
-                        dcc.Checklist(
-                            options=["Select all"],
-                            value=[],
+                        html.Div("Realization", style={"width": "50%"}),
+                        html.Button(
+                            "Select all",
                             id=all_real_id,
+                            style=LayoutStyle.ALL_REAL_BUTTON,
+                            n_clicks=0,
                         ),
                     ],
                     style={
                         "display": "flex",
                         "flex-direction": "row",
+                        "margin-top": "3px",
+                        "margin-bottom": "3px",
                     },
                 ),
                 wcc.SelectWithLabel(

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -39,6 +39,7 @@ class ViewSettings(SettingsGroupABC):
         FORMATION = "formation"
         ENSEMBLE = "ensemble"
         REALIZATION = "realization"
+        ALL_REAL = "all-realizations"
 
         PROPERTY = "property"
         STATISTIC = "statistic"
@@ -54,6 +55,8 @@ class ViewSettings(SettingsGroupABC):
         Y_MAX_GRAPH = "y-max-graph"
         Y_MIN_AUTO_GRAPH = "y-min-auto-graph"
         Y_MAX_AUTO_GRAPH = "y-max-auto-graph"
+        Y_LIM_OPTIONS = "y_limit_options"
+        REAL_OR_STAT = "realization-or-statistics"
         COLOR_BY = "color-by"
         MARK_BY = "mark-by"
         SORT_PLOT = "sort-plot"
@@ -119,6 +122,7 @@ class ViewSettings(SettingsGroupABC):
             EnsembleSelectorLayout(
                 self.register_component_unique_id(self.Ids.ENSEMBLE),
                 self.register_component_unique_id(self.Ids.REALIZATION),
+                self.register_component_unique_id(self.Ids.ALL_REAL),
                 list(self._ensemble_paths.keys()),
             )
         )
@@ -174,6 +178,8 @@ class ViewSettings(SettingsGroupABC):
                         self.register_component_unique_id(self.Ids.CONTAINMENT_MENU),
                         self.register_component_unique_id(self.Ids.PLUME_GROUP),
                         self.register_component_unique_id(self.Ids.PLUME_GROUP_MENU),
+                        self.register_component_unique_id(self.Ids.REAL_OR_STAT),
+                        self.register_component_unique_id(self.Ids.Y_LIM_OPTIONS),
                     ],
                     self._content,
                 )
@@ -197,14 +203,19 @@ class ViewSettings(SettingsGroupABC):
                 self.component_unique_id(self.Ids.REALIZATION).to_string(), "options"
             ),
             Output(self.component_unique_id(self.Ids.REALIZATION).to_string(), "value"),
+            Output(self.component_unique_id(self.Ids.ALL_REAL).to_string(), "value"),
             Input(self.component_unique_id(self.Ids.ENSEMBLE).to_string(), "value"),
+            Input(self.component_unique_id(self.Ids.ALL_REAL).to_string(), "value"),
         )
-        def set_realizations(ensemble: str) -> Tuple[List[Dict[str, Any]], List[int]]:
+        def set_realizations(
+            ensemble: str,
+            select_all: List[str],
+        ) -> Tuple[List[Dict[str, Any]], List[int]]:
             rlz = [
                 {"value": r, "label": str(r)}
                 for r in self._realizations_per_ensemble[ensemble]
             ]
-            return rlz, [rlz[0]["value"]]  # type: ignore
+            return rlz, self._realizations_per_ensemble[ensemble], []  # type: ignore
 
         @callback(
             Output(self.component_unique_id(self.Ids.FORMATION).to_string(), "options"),
@@ -1021,32 +1032,57 @@ class GraphSelectorsLayout(wcc.Selectors):
                     style={"display": "flex"},
                 ),
                 html.Div(
-                    "Fix y-limits in third plot:",
+                    "Time plot options:",
                     style={"margin-top": "10px"},
                 ),
-                "Minimum",
                 html.Div(
                     [
-                        dcc.Input(id=y_min_ids[0], type="number"),
-                        dcc.Checklist(
-                            ["Auto"],
-                            ["Auto"],
-                            id=y_min_ids[1],
+                        dcc.RadioItems(
+                            options=[
+                                {"label": "Realizations", "value": "real"},
+                                {"label": "Mean/P10/P90", "value": "stat"}],
+                            value="real",
+                            id=containment_ids[14],
+                            inline=True,
                         ),
                     ],
-                    style=self._CM_RANGE,
+                    style={
+                        "display": "flex",
+                        "flex-direction": "row",
+                    },
                 ),
-                "Maximum",
                 html.Div(
                     [
-                        dcc.Input(id=y_max_ids[0], type="number"),
-                        dcc.Checklist(
-                            ["Auto"],
-                            ["Auto"],
-                            id=y_max_ids[1],
+                        "Fix minimum y-value",
+                        html.Div(
+                            [
+                                dcc.Input(id=y_min_ids[0], type="number"),
+                                dcc.Checklist(
+                                    ["Auto"],
+                                    ["Auto"],
+                                    id=y_min_ids[1],
+                                ),
+                            ],
+                            style=self._CM_RANGE,
+                        ),
+                        "Fix maximum y-value",
+                        html.Div(
+                            [
+                                dcc.Input(id=y_max_ids[0], type="number"),
+                                dcc.Checklist(
+                                    ["Auto"],
+                                    ["Auto"],
+                                    id=y_max_ids[1],
+                                ),
+                            ],
+                            style=self._CM_RANGE,
                         ),
                     ],
-                    style=self._CM_RANGE,
+                    style={
+                        "display": "flex",
+                        "flex-direction": "column",
+                    },
+                    id=containment_ids[15],
                 ),
             ],
         )
@@ -1094,7 +1130,13 @@ class ExperimentalFeaturesLayout(wcc.Selectors):
 
 
 class EnsembleSelectorLayout(wcc.Selectors):
-    def __init__(self, ensemble_id: str, realization_id: str, ensembles: List[str]):
+    def __init__(
+            self,
+            ensemble_id: str,
+            realization_id: str,
+            all_real_id: str,
+            ensembles: List[str],
+    ):
         super().__init__(
             label="Ensemble",
             open_details=True,
@@ -1106,7 +1148,21 @@ class EnsembleSelectorLayout(wcc.Selectors):
                     value=ensembles[0],
                     clearable=False,
                 ),
-                "Realization",
+                html.Div(
+                    [
+                        "Realization",
+                        html.Div("", style={"width": "25px"}),
+                        dcc.Checklist(
+                            options=["Select all"],
+                            value=[],
+                            id=all_real_id,
+                        )
+                    ],
+                    style={
+                        "display": "flex",
+                        "flex-direction": "row",
+                    }
+                ),
                 wcc.SelectWithLabel(
                     id=realization_id,
                     value=[],


### PR DESCRIPTION
Solves https://github.com/equinor/ccs-scripts/issues/190 and https://github.com/equinor/ccs-scripts/issues/193

New button in the menu to quickly select all realizations (which is also the new standard upon initialization).

If multiple or all realizations are selected: Line plot (previously middle tab) showing each realization, or, if selected in the menu, showing a line for P10, a line for the mean, and a line for P90.
 
If one realization is selected: Stacked line plot (previously the rightmost tab), where we still have the option in the menu to fix the y-range to be able to compare realizations.