### PR TITLE
CCS-343: Prevent crash with no dated maps

### DIFF
--- a/webviz_subsurface/plugins/_co2_migration/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_migration/_plugin.py
@@ -41,6 +41,7 @@ from webviz_subsurface.plugins._co2_migration._utilities.generic import (
 )
 from webviz_subsurface.plugins._co2_migration._utilities.initialization import (
     init_containment_data_providers,
+    init_dates_per_ensemble,
     init_dictionary_of_content,
     init_map_attribute_names,
     init_menu_options,
@@ -195,6 +196,10 @@ class CO2Migration(WebvizPluginABC):
             self._ensemble_surface_providers = init_surface_providers(
                 webviz_settings, ensembles
             )
+            # Dates
+            self._ensemble_dates = init_dates_per_ensemble(
+                ensembles, self._map_attribute_names, self._ensemble_surface_providers
+            )
             # Polygons
             self._fault_polygon_handlers = {
                 ens: FaultPolygonsHandler(
@@ -295,22 +300,6 @@ class CO2Migration(WebvizPluginABC):
             .component_unique_id(component_id)
             .to_string()
         )
-
-    def _ensemble_dates(self, ens: str) -> List[str]:
-        surface_provider = self._ensemble_surface_providers[ens]
-        dated_attributes = [
-            k
-            for k in self._map_attribute_names.filtered_values
-            if MapType[k.name].value != "MIGRATION_TIME"
-        ]
-        if len(dated_attributes) == 0:
-            return None
-        date_map_attribute = dated_attributes[0]
-        att_name = self._map_attribute_names[date_map_attribute]
-        dates = surface_provider.surface_dates_for_attribute(att_name)
-        if dates is None:
-            raise ValueError(f"Failed to fetch dates for attribute '{att_name}'")
-        return dates
 
     # Might want to do some refactoring if this gets too big
     def _set_callbacks(self) -> None:
@@ -516,10 +505,8 @@ class CO2Migration(WebvizPluginABC):
                 raise PreventUpdate
             if MapType[MapAttribute(attribute).name].value == "MIGRATION_TIME":
                 datestr = None
-            elif isinstance(date, int):
-                datestr = self._ensemble_dates(ensemble)[date]
             else:
-                datestr = None
+                datestr = self._ensemble_dates[ensemble][date]
             # Contour data
             contour_data = None
             if MapType[MapAttribute(attribute).name].value == "PLUME":
@@ -651,15 +638,12 @@ class CO2Migration(WebvizPluginABC):
             if ensemble is None:
                 return {}, None
             # Dates
-            date_list = self._ensemble_dates(ensemble)
-            if date_list is None:  # The case if the only maps are migration time maps
-                return None, None
             dates = {
                 i: {
                     "label": f"{d[:4]}",
                     "style": {"writingMode": "vertical-rl"},
                 }
-                for i, d in enumerate(date_list)
+                for i, d in enumerate(self._ensemble_dates[ensemble])
             }
             if len(dates.keys()) > 0:
                 return dates, max(dates.keys())

--- a/webviz_subsurface/plugins/_co2_migration/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_migration/_utilities/callbacks.py
@@ -187,7 +187,7 @@ def get_plume_polygon(
     surface_provider: EnsembleSurfaceProvider,
     realizations: List[int],
     surface_name: str,
-    datestr: str,
+    datestr: Optional[str],
     contour_data: Dict[str, Any],
 ) -> Optional[geojson.FeatureCollection]:
     surface_attribute = contour_data["property"]
@@ -624,7 +624,7 @@ def set_plot_ids(
 def process_summed_mass(
     formation: str,
     realization: List[int],
-    datestr: str,
+    datestr: Optional[str],
     attribute: MapAttribute,
     summed_mass: Optional[float],
     surf_data: Optional[SurfaceData],

--- a/webviz_subsurface/plugins/_co2_migration/_utilities/initialization.py
+++ b/webviz_subsurface/plugins/_co2_migration/_utilities/initialization.py
@@ -28,6 +28,7 @@ from webviz_subsurface.plugins._co2_migration._utilities.generic import (
     FilteredMapAttribute,
     GraphSource,
     MapAttribute,
+    MapType,
     MapNamingConvention,
     MenuOptions,
     PhasesScenario,
@@ -141,6 +142,34 @@ def init_surface_providers(
         )
         for ens in ensembles
     }
+
+
+def init_dates_per_ensemble(
+    ensembles: List[str],
+    attribute_names: FilteredMapAttribute,
+    surface_providers: Dict[str, EnsembleSurfaceProvider],
+) -> Dict[str, List[str]]:
+    ensemble_dates: Dict[str, List[str]] = {}
+    for ens in ensembles:
+        surface_provider = surface_providers[ens]
+        dated_attributes = [
+            k
+            for k in attribute_names.filtered_values
+            if MapType[k.name].value != "MIGRATION_TIME"
+        ]
+        if len(dated_attributes) == 0:
+            ensemble_dates[ens] = []
+        else:
+            date_map_attribute = dated_attributes[0]
+            att_name = attribute_names[date_map_attribute]
+            dates = surface_provider.surface_dates_for_attribute(att_name)
+            if dates is None:
+                raise ValueError(
+                    f"Failed to fetch dates in ensemble {ens} "
+                    f"for attribute '{att_name}'"
+                )
+            ensemble_dates[ens] = dates
+    return ensemble_dates
 
 
 def init_well_pick_provider(


### PR DESCRIPTION
Solves an issue where the plugin crashes if it is run with only maps without dates (migration time) https://github.com/equinor/ccs-scripts/issues/343. Function collecting dates moved to initialization of the module.

Also includes a minor change to display only the selected realizations (and not necessarily all realizations) in the containment state plot.